### PR TITLE
Compiler warnings and Rule of Zero on SensorInterface

### DIFF
--- a/ros2_ouster/include/ros2_ouster/interfaces/sensor_interface.hpp
+++ b/ros2_ouster/include/ros2_ouster/interfaces/sensor_interface.hpp
@@ -31,6 +31,7 @@ class SensorInterface
 public:
   using SharedPtr = std::shared_ptr<SensorInterface>;
   using Ptr = std::unique_ptr<SensorInterface>;
+
   /**
    * @brief A sensor interface constructor
    */
@@ -39,7 +40,15 @@ public:
   /**
    * @brief A sensor interface destructor
    */
-  virtual ~SensorInterface() {}
+  virtual ~SensorInterface() = default;
+
+  // copy
+  SensorInterface(const SensorInterface&) = delete;
+  SensorInterface& operator=(const SensorInterface&) = delete;
+
+  // move
+  SensorInterface(SensorInterface&&) = default;
+  SensorInterface& operator=(SensorInterface&&) = default;
 
   /**
    * @brief Reset lidar sensor

--- a/ros2_ouster/include/ros2_ouster/interfaces/sensor_interface.hpp
+++ b/ros2_ouster/include/ros2_ouster/interfaces/sensor_interface.hpp
@@ -44,11 +44,11 @@ public:
 
   // copy
   SensorInterface(const SensorInterface &) = delete;
-  SensorInterface& operator=(const SensorInterface &) = delete;
+  SensorInterface & operator=(const SensorInterface &) = delete;
 
   // move
   SensorInterface(SensorInterface &&) = default;
-  SensorInterface& operator=(SensorInterface &&) = default;
+  SensorInterface & operator=(SensorInterface &&) = default;
 
   /**
    * @brief Reset lidar sensor

--- a/ros2_ouster/include/ros2_ouster/interfaces/sensor_interface.hpp
+++ b/ros2_ouster/include/ros2_ouster/interfaces/sensor_interface.hpp
@@ -43,12 +43,12 @@ public:
   virtual ~SensorInterface() = default;
 
   // copy
-  SensorInterface(const SensorInterface&) = delete;
-  SensorInterface& operator=(const SensorInterface&) = delete;
+  SensorInterface(const SensorInterface &) = delete;
+  SensorInterface& operator=(const SensorInterface &) = delete;
 
   // move
-  SensorInterface(SensorInterface&&) = default;
-  SensorInterface& operator=(SensorInterface&&) = default;
+  SensorInterface(SensorInterface &&) = default;
+  SensorInterface& operator=(SensorInterface &&) = default;
 
   /**
    * @brief Reset lidar sensor

--- a/ros2_ouster/include/ros2_ouster/interfaces/sensor_interface.hpp
+++ b/ros2_ouster/include/ros2_ouster/interfaces/sensor_interface.hpp
@@ -45,32 +45,32 @@ public:
    * @brief Reset lidar sensor
    * @param configuration file to use
    */
-  virtual void reset(const ros2_ouster::Configuration & config) {}
+  virtual void reset(const ros2_ouster::Configuration & config) = 0;
 
   /**
    * @brief Configure lidar sensor
    * @param configuration file to use
    */
-  virtual void configure(const ros2_ouster::Configuration & config) {}
+  virtual void configure(const ros2_ouster::Configuration & config) = 0;
 
   /**
    * @brief Ask sensor to get its current state for data collection
    * @return the state enum value
    */
-  virtual ros2_ouster::ClientState get() {}
+  virtual ros2_ouster::ClientState get() = 0;
 
   /**
    * @brief reading the packet corresponding to the sensor state
    * @param state of the sensor
    * @return the packet of data
    */
-  virtual uint8_t * readPacket(const ros2_ouster::ClientState & state) {}
+  virtual uint8_t * readPacket(const ros2_ouster::ClientState & state) = 0;
 
   /**
    * @brief Get lidar sensor's metadata
    * @return sensor metadata struct
    */
-  virtual ros2_ouster::Metadata getMetadata() {}
+  virtual ros2_ouster::Metadata getMetadata() = 0;
 };
 
 }  // namespace ros2_ouster

--- a/ros2_ouster/src/OS1/OS1_sensor.cpp
+++ b/ros2_ouster/src/OS1/OS1_sensor.cpp
@@ -93,6 +93,8 @@ uint8_t * OS1Sensor::readPacket(const ros2_ouster::ClientState & state)
         return nullptr;
       }
   }
+
+  return nullptr;
 }
 
 ros2_ouster::Metadata OS1Sensor::getMetadata()


### PR DESCRIPTION
I was getting some ugly compiler warnings building the code (I'm using g++ 9.2.1 on Ubuntu 18.04). This was as a result of having empty implementations for the declared methods on the `SensorInterface`. I think the intent was to define an ABT / interface and to that end I made those functions pure virtual. There was also an issue with a control flow path that did not provide a return value, so I fixed that too.

In addition to the warnings, while in the `SensorInterface` I saw that we necessarily have to declare the dtor virtual, and so to be in compliance to the Rule of Zero, I added explicit implementations for the other four special functions -- namely those related to copy and move semantics -- per guidance in the C++ Core Guidelines. More info and references in the commit messages.