### PR TITLE
Fix the build under Clang

### DIFF
--- a/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
+++ b/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
@@ -51,12 +51,24 @@ public:
    * @brief A constructor for ros2_ouster::OusterDriver
    * @param options Node options for lifecycle node interfaces
    */
-  explicit OusterDriver(const rclcpp::NodeOptions & options);
+  explicit OusterDriver(const rclcpp::NodeOptions & options)
+  : LifecycleInterface("OusterDriver", options)
+  {
+    this->declare_parameter("lidar_ip");
+    this->declare_parameter("computer_ip");
+    this->declare_parameter("imu_port", 7503);
+    this->declare_parameter("lidar_port", 7502);
+    this->declare_parameter("lidar_mode", std::string("512x10"));
+    this->declare_parameter("sensor_frame", std::string("laser_sensor_frame"));
+    this->declare_parameter("laser_frame", std::string("laser_data_frame"));
+    this->declare_parameter("imu_frame", std::string("imu_data_frame"));
+    this->declare_parameter("use_system_default_qos", false);
+  }
 
   /**
    * @brief A destructor for ros2_ouster::OusterDriver
    */
-  ~OusterDriver();
+  ~OusterDriver() override = default;
 
   /**
    * @brief lifecycle node's implementation of configure step
@@ -130,7 +142,7 @@ private:
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr _reset_srv;
   rclcpp::Service<ouster_msgs::srv::GetMetadata>::SharedPtr _metadata_srv;
 
-  typename SensorT::SharedPtr _sensor;
+  std::shared_ptr<SensorT> _sensor;
   std::multimap<ClientState, DataProcessorInterface *> _data_processors;
   rclcpp::TimerBase::SharedPtr _process_timer;
 

--- a/ros2_ouster/include/ros2_ouster/point_os.hpp
+++ b/ros2_ouster/include/ros2_ouster/point_os.hpp
@@ -61,9 +61,11 @@ struct EIGEN_ALIGN16 PointOS
 }  // namespace point_os
 
 // clang-format off
-POINT_CLOUD_REGISTER_POINT_STRUCT(point_os::PointOS,
-  (float, x, x)(float, y, y)(float, z, z)(float, intensity, intensity)(uint32_t, t, t)(uint16_t,
-  reflectivity, reflectivity)(uint8_t, ring, ring)(uint16_t, noise, noise)(uint32_t, range, range)
+POINT_CLOUD_REGISTER_POINT_STRUCT(
+  point_os::PointOS,
+  (float, x, x)(float, y, y)(float, z, z)(float, intensity, intensity)(uint32_t, t, t)(
+    uint16_t,
+    reflectivity, reflectivity)(uint8_t, ring, ring)(uint16_t, noise, noise)(uint32_t, range, range)
 )
 
 #endif  // ROS2_OUSTER__POINT_OS_HPP_

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -30,26 +30,6 @@ using std::placeholders::_3;
 using namespace std::chrono_literals;
 
 template<typename SensorT>
-OusterDriver<SensorT>::OusterDriver(const rclcpp::NodeOptions & options)
-: LifecycleInterface("OusterDriver", options)
-{
-  this->declare_parameter("lidar_ip");
-  this->declare_parameter("computer_ip");
-  this->declare_parameter("imu_port", 7503);
-  this->declare_parameter("lidar_port", 7502);
-  this->declare_parameter("lidar_mode", std::string("512x10"));
-  this->declare_parameter("sensor_frame", std::string("laser_sensor_frame"));
-  this->declare_parameter("laser_frame", std::string("laser_data_frame"));
-  this->declare_parameter("imu_frame", std::string("imu_data_frame"));
-  this->declare_parameter("use_system_default_qos", false);
-}
-
-template<typename SensorT>
-OusterDriver<SensorT>::~OusterDriver()
-{
-}
-
-template<typename SensorT>
 void OusterDriver<SensorT>::onConfigure()
 {
   ros2_ouster::Configuration lidar_config;


### PR DESCRIPTION
```
ld.lld: error: undefined symbol: ros2_ouster::OusterDriver<OS1::OS1Sensor>::OusterDriver(rclcpp::NodeOptions const&)
>>> referenced by new_allocator.h:147 (/usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/ext/new_allocator.h:147)
>>>               CMakeFiles/ouster_driver.dir/src/main.cpp.o:(std::__shared_ptr<ros2_ouster::OusterDriver<OS1::OS1Sensor>, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<ros2_ouster::OusterDriver<OS1::OS1Sensor> >, rclcpp::NodeOptions&>(std::_Sp_alloc_shared_tag<std::allocator<ros2_ouster::OusterDriver<OS1::OS1Sensor> > >, rclcpp::NodeOptions&))

ld.lld: error: undefined symbol: ros2_ouster::OusterDriver<OS1::OS1Sensor>::~OusterDriver()
>>> referenced by main.cpp
>>>               CMakeFiles/ouster_driver.dir/src/main.cpp.o:(vtable for ros2_ouster::OusterDriver<OS1::OS1Sensor>)
>>> did you mean: ros2_ouster::OusterDriver<OS1::OS1Sensor>::~OusterDriver()
>>> defined in: libouster_driver_core.so
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [CMakeFiles/ouster_driver.dir/build.make:157: ouster_driver] Error 1
make[1]: *** [CMakeFiles/Makefile2:78: CMakeFiles/ouster_driver.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```
