### PR TITLE
Stylistic changes

### DIFF
--- a/ros2_ouster/include/ros2_ouster/OS1/processors/image_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/image_processor.hpp
@@ -40,8 +40,8 @@ namespace OS1
 class ImageProcessor : public ros2_ouster::DataProcessorInterface
 {
 public:
-  typedef std::vector<image_os::ImageOS> OSImage;
-  typedef OSImage::iterator OSImageIt;
+  using OSImage = std::vector<image_os::ImageOS>;
+  using OSImageIt = OSImage::iterator;
 
   /**
    * @brief A constructor for OS1::ImageProcessor

--- a/ros2_ouster/include/ros2_ouster/OS1/processors/scan_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/scan_processor.hpp
@@ -39,8 +39,8 @@ namespace OS1
 class ScanProcessor : public ros2_ouster::DataProcessorInterface
 {
 public:
-  typedef std::vector<scan_os::ScanOS> OSScan;
-  typedef OSScan::iterator OSScanIt;
+  using OSScan = std::vector<scan_os::ScanOS>;
+  using OSScanIt = OSScan::iterator;
 
   /**
    * @brief A constructor for OS1::ScanProcessor

--- a/ros2_ouster/include/ros2_ouster/driver_types.hpp
+++ b/ros2_ouster/include/ros2_ouster/driver_types.hpp
@@ -26,7 +26,7 @@ namespace ros2_ouster
 {
 
 template class ros2_ouster::OusterDriver<OS1::OS1Sensor>;
-typedef ros2_ouster::OusterDriver<OS1::OS1Sensor> OS1Driver;
+using OS1Driver = ros2_ouster::OusterDriver<OS1::OS1Sensor>;
 
 }  // namespace ros2_ouster
 

--- a/ros2_ouster/include/ros2_ouster/interfaces/data_processor_interface.hpp
+++ b/ros2_ouster/include/ros2_ouster/interfaces/data_processor_interface.hpp
@@ -39,6 +39,11 @@ public:
   DataProcessorInterface() {}
 
   /**
+   * @brief Destructor of the data processor interface
+   */
+  virtual ~DataProcessorInterface() = default;
+
+  /**
    * @brief Process a packet with the lidar-specific APIs
    * @param data packet input
    */

--- a/ros2_ouster/include/ros2_ouster/point_os.hpp
+++ b/ros2_ouster/include/ros2_ouster/point_os.hpp
@@ -62,8 +62,15 @@ struct EIGEN_ALIGN16 PointOS
 
 // clang-format off
 POINT_CLOUD_REGISTER_POINT_STRUCT(point_os::PointOS,
-  (float, x, x)(float, y, y)(float, z, z)(float, intensity, intensity)(uint32_t, t, t)(uint16_t,
-  reflectivity, reflectivity)(uint8_t, ring, ring)(uint16_t, noise, noise)(uint32_t, range, range)
+  (float, x, x)
+  (float, y, y)
+  (float, z, z)
+  (float, intensity, intensity)
+  (std::uint32_t, t, t)
+  (std::uint16_t, reflectivity, reflectivity)
+  (std::uint8_t, ring, ring)
+  (std::uint16_t, noise, noise)
+  (std::uint32_t, range, range)
 )
 
 #endif  // ROS2_OUSTER__POINT_OS_HPP_

--- a/ros2_ouster/include/ros2_ouster/point_os.hpp
+++ b/ros2_ouster/include/ros2_ouster/point_os.hpp
@@ -60,7 +60,7 @@ struct EIGEN_ALIGN16 PointOS
 
 }  // namespace point_os
 
-// clang-format off
+/* *INDENT-OFF* */
 POINT_CLOUD_REGISTER_POINT_STRUCT(point_os::PointOS,
   (float, x, x)
   (float, y, y)
@@ -72,5 +72,6 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(point_os::PointOS,
   (std::uint16_t, noise, noise)
   (std::uint32_t, range, range)
 )
+/* *INDENT-ON* */
 
 #endif  // ROS2_OUSTER__POINT_OS_HPP_

--- a/ros2_ouster/src/OS1/OS1_sensor.cpp
+++ b/ros2_ouster/src/OS1/OS1_sensor.cpp
@@ -92,9 +92,9 @@ uint8_t * OS1Sensor::readPacket(const ros2_ouster::ClientState & state)
       } else {
         return nullptr;
       }
+    default:
+      return nullptr;
   }
-
-  return nullptr;
 }
 
 ros2_ouster::Metadata OS1Sensor::getMetadata()


### PR DESCRIPTION
Mostly cleaning up warnings.

- Conform better to PCL library Point Struct style
- Add missing virtual destructor to base class
- Switch from `typedef` to `using`
- Fix warning about missing switch cases

I can split this into multiple PRs if you prefer.