### PR TITLE
Clean up destructor code

### DIFF
--- a/ros2_ouster/include/ros2_ouster/OS1/OS1_sensor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/OS1_sensor.hpp
@@ -31,8 +31,6 @@ class OS1Sensor : public ros2_ouster::SensorInterface
 public:
   OS1Sensor();
 
-  ~OS1Sensor() override;
-
   /**
    * @brief Reset lidar sensor
    * @param configuration file to use
@@ -65,9 +63,10 @@ public:
   uint8_t * readPacket(const ros2_ouster::ClientState & state) override;
 
 private:
-  std::shared_ptr<client> _ouster_client;
   std::vector<uint8_t> _lidar_packet;
   std::vector<uint8_t> _imu_packet;
+
+  std::shared_ptr<client> _ouster_client;
 };
 
 }  // namespace OS1

--- a/ros2_ouster/include/ros2_ouster/OS1/processors/image_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/image_processor.hpp
@@ -159,17 +159,6 @@ public:
   }
 
   /**
-   * @brief A destructor clearing memory allocated
-   */
-  ~ImageProcessor()
-  {
-    _reflectivity_image_pub.reset();
-    _intensity_image_pub.reset();
-    _noise_image_pub.reset();
-    _range_image_pub.reset();
-  }
-
-  /**
    * @brief Process method to create images
    * @param data the packet data
    */
@@ -203,10 +192,6 @@ public:
   }
 
 private:
-  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Image>::SharedPtr _reflectivity_image_pub;
-  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Image>::SharedPtr _intensity_image_pub;
-  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Image>::SharedPtr _range_image_pub;
-  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Image>::SharedPtr _noise_image_pub;
   std::function<void(const uint8_t *, OSImageIt)> _batch_and_publish;
   rclcpp_lifecycle::LifecycleNode::SharedPtr _node;
   sensor_msgs::msg::Image _reflectivity_image;
@@ -219,6 +204,11 @@ private:
   std::string _frame;
   uint32_t _height;
   uint32_t _width;
+
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Image>::SharedPtr _reflectivity_image_pub;
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Image>::SharedPtr _intensity_image_pub;
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Image>::SharedPtr _range_image_pub;
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Image>::SharedPtr _noise_image_pub;
 };
 
 }  // namespace OS1

--- a/ros2_ouster/include/ros2_ouster/OS1/processors/image_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/image_processor.hpp
@@ -193,7 +193,6 @@ public:
 
 private:
   std::function<void(const uint8_t *, OSImageIt, uint64_t)> _batch_and_publish;
-  rclcpp_lifecycle::LifecycleNode::SharedPtr _node;
   sensor_msgs::msg::Image _reflectivity_image;
   sensor_msgs::msg::Image _intensity_image;
   sensor_msgs::msg::Image _range_image;
@@ -205,6 +204,7 @@ private:
   uint32_t _height;
   uint32_t _width;
 
+  rclcpp_lifecycle::LifecycleNode::SharedPtr _node;
   rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Image>::SharedPtr _reflectivity_image_pub;
   rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Image>::SharedPtr _intensity_image_pub;
   rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Image>::SharedPtr _range_image_pub;

--- a/ros2_ouster/include/ros2_ouster/OS1/processors/imu_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/imu_processor.hpp
@@ -54,14 +54,6 @@ public:
   }
 
   /**
-   * @brief A destructor clearing memory allocated
-   */
-  ~IMUProcessor()
-  {
-    _pub.reset();
-  }
-
-  /**
    * @brief Process method to create imu
    * @param data the packet data
    */
@@ -90,9 +82,10 @@ public:
   }
 
 private:
-  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Imu>::SharedPtr _pub;
-  rclcpp_lifecycle::LifecycleNode::SharedPtr _node;
   std::string _frame;
+
+  rclcpp_lifecycle::LifecycleNode::SharedPtr _node;
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Imu>::SharedPtr _pub;
 };
 
 }  // namespace OS1

--- a/ros2_ouster/include/ros2_ouster/OS1/processors/pointcloud_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/pointcloud_processor.hpp
@@ -106,13 +106,14 @@ private:
   std::function<void(const uint8_t *,
     pcl::PointCloud<point_os::PointOS>::iterator, uint64_t)>
   _batch_and_publish;
-  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::PointCloud2>::SharedPtr _pub;
   std::shared_ptr<pcl::PointCloud<point_os::PointOS>> _cloud;
-  rclcpp_lifecycle::LifecycleNode::SharedPtr _node;
   std::vector<double> _xyz_lut;
   std::string _frame;
   uint32_t _height;
   uint32_t _width;
+
+  rclcpp_lifecycle::LifecycleNode::SharedPtr _node;
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::PointCloud2>::SharedPtr _pub;
 };
 
 }  // namespace OS1

--- a/ros2_ouster/include/ros2_ouster/OS1/processors/pointcloud_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/pointcloud_processor.hpp
@@ -76,14 +76,6 @@ public:
   }
 
   /**
-   * @brief A destructor clearing memory allocated
-   */
-  ~PointcloudProcessor()
-  {
-    _pub.reset();
-  }
-
-  /**
    * @brief Process method to create pointcloud
    * @param data the packet data
    */

--- a/ros2_ouster/include/ros2_ouster/OS1/processors/scan_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/scan_processor.hpp
@@ -87,14 +87,6 @@ public:
   }
 
   /**
-   * @brief A destructor clearing memory allocated
-   */
-  ~ScanProcessor()
-  {
-    _pub.reset();
-  }
-
-  /**
    * @brief Process method to create scan
    * @param data the packet data
    */
@@ -122,10 +114,8 @@ public:
   }
 
 private:
-  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::LaserScan>::SharedPtr _pub;
   std::function<void(const uint8_t *, OSScanIt)> _batch_and_publish;
   std::shared_ptr<pcl::PointCloud<scan_os::ScanOS>> _cloud;
-  rclcpp_lifecycle::LifecycleNode::SharedPtr _node;
   std::vector<double> _xyz_lut;
   ros2_ouster::Metadata _mdata;
   OSScan _aggregated_scans;
@@ -133,6 +123,9 @@ private:
   uint32_t _height;
   uint32_t _width;
   uint8_t _ring;
+
+  rclcpp_lifecycle::LifecycleNode::SharedPtr _node;
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::LaserScan>::SharedPtr _pub;
 };
 
 }  // namespace OS1

--- a/ros2_ouster/include/ros2_ouster/interfaces/data_processor_interface.hpp
+++ b/ros2_ouster/include/ros2_ouster/interfaces/data_processor_interface.hpp
@@ -36,7 +36,7 @@ public:
   /**
    * @brief Constructor of the data processor interface
    */
-  DataProcessorInterface() {}
+  DataProcessorInterface() = default;
 
   /**
    * @brief Destructor of the data processor interface

--- a/ros2_ouster/include/ros2_ouster/interfaces/lifecycle_interface.hpp
+++ b/ros2_ouster/include/ros2_ouster/interfaces/lifecycle_interface.hpp
@@ -33,7 +33,6 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
 class LifecycleInterface : public rclcpp_lifecycle::LifecycleNode
 {
 public:
-
   /**
    * @brief Destructor
    */

--- a/ros2_ouster/include/ros2_ouster/interfaces/lifecycle_interface.hpp
+++ b/ros2_ouster/include/ros2_ouster/interfaces/lifecycle_interface.hpp
@@ -33,6 +33,12 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
 class LifecycleInterface : public rclcpp_lifecycle::LifecycleNode
 {
 public:
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~LifecycleInterface() = default;
+
   /**
    * @brief A constructor for lifecycle_interface::LifecycleInterface
    * @param name Name of node

--- a/ros2_ouster/include/ros2_ouster/interfaces/sensor_interface.hpp
+++ b/ros2_ouster/include/ros2_ouster/interfaces/sensor_interface.hpp
@@ -35,7 +35,7 @@ public:
   /**
    * @brief A sensor interface constructor
    */
-  SensorInterface() {}
+  SensorInterface() = default;
 
   /**
    * @brief A sensor interface destructor

--- a/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
+++ b/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
@@ -127,18 +127,17 @@ private:
     const std::shared_ptr<ouster_msgs::srv::GetMetadata::Request> request,
     std::shared_ptr<ouster_msgs::srv::GetMetadata::Response> response);
 
-  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr _reset_srv;
-  rclcpp::Service<ouster_msgs::srv::GetMetadata>::SharedPtr _metadata_srv;
-
-  typename SensorT::SharedPtr _sensor;
-  std::multimap<ClientState, DataProcessorInterface *> _data_processors;
-  rclcpp::TimerBase::SharedPtr _process_timer;
-
   std::string _laser_sensor_frame, _laser_data_frame, _imu_data_frame;
-  std::unique_ptr<tf2_ros::StaticTransformBroadcaster> _tf_b;
 
   bool _use_system_default_qos;
   bool _use_ros_time;
+
+  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr _reset_srv;
+  rclcpp::Service<ouster_msgs::srv::GetMetadata>::SharedPtr _metadata_srv;
+  typename SensorT::SharedPtr _sensor;
+  std::multimap<ClientState, DataProcessorInterface *> _data_processors;
+  rclcpp::TimerBase::SharedPtr _process_timer;
+  std::unique_ptr<tf2_ros::StaticTransformBroadcaster> _tf_b;
 };
 
 }  // namespace ros2_ouster

--- a/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
+++ b/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
@@ -56,7 +56,7 @@ public:
   /**
    * @brief A destructor for ros2_ouster::OusterDriver
    */
-  ~OusterDriver();
+  ~OusterDriver() = default;
 
   /**
    * @brief lifecycle node's implementation of configure step

--- a/ros2_ouster/src/OS1/OS1_sensor.cpp
+++ b/ros2_ouster/src/OS1/OS1_sensor.cpp
@@ -28,13 +28,6 @@ OS1Sensor::OS1Sensor()
   _imu_packet.resize(imu_packet_bytes + 1);
 }
 
-OS1Sensor::~OS1Sensor()
-{
-  _ouster_client.reset();
-  _lidar_packet.clear();
-  _imu_packet.clear();
-}
-
 void OS1Sensor::reset(const ros2_ouster::Configuration & config)
 {
   _ouster_client.reset();

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -45,11 +45,6 @@ OusterDriver<SensorT>::OusterDriver(const rclcpp::NodeOptions & options)
 }
 
 template<typename SensorT>
-OusterDriver<SensorT>::~OusterDriver()
-{
-}
-
-template<typename SensorT>
 void OusterDriver<SensorT>::onConfigure()
 {
   ros2_ouster::Configuration lidar_config;


### PR DESCRIPTION
Much of the destructor code is unnecessary as the default destructor calls member destructors in reverse order. Where necessary, rearranged fields to make sure this order is the correct one.