### PR TITLE
Use CMake more modularly

### DIFF
--- a/ros2_ouster/CMakeLists.txt
+++ b/ros2_ouster/CMakeLists.txt
@@ -47,6 +47,11 @@ add_library(${library_name} SHARED
   src/OS1/OS1_sensor.cpp
 )
 
+target_include_directories(${library_name} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
 ament_target_dependencies(${library_name}
   ${dependencies}
 )


### PR DESCRIPTION
1. Use target-based include directories instead of global
2. Use generator expressions so when building, we don't accidentally look in the installed version of this package
3. Link to pcl through the pcl_common target so we don't need to separately specify its LIBRARIES and INCLUDE_DIRS
