### PR TITLE
Support for accessing and mutating the timestamp mode on the LiDAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,54 @@ See design doc in `design/*` directory [here](ros2_ouster/design/design_doc.md).
 
 </center>
 
-Note: TF will provide you the transformations from the sensor frame to each of the data frames.
+Note: TF will provide you the transformations from the sensor frame to each of
+the data frames.
+
+### Timestamp Modes
+
+Referring to the parameter table above, the `timestamp_mode` parameter has four
+allowable options (as of this writing). They are: `TIME_FROM_INTERNAL_OSC`,
+`TIME_FROM_SYNC_PULSE_IN`, `TIME_FROM_PTP_1588`, `TIME_FROM_ROS_RECEPTION`. A
+description of each now follows.
+
+#### `TIME_FROM_INTERNAL_OSC`
+
+Use the LiDAR internal clock. Measurements are time stamped with ns since
+power-on. Free running counter based on the OS1’s internal oscillator. Counts
+seconds and nanoseconds since OS1 turn on, reported at ns resolution (both a
+second and nanosecond register in every UDP packet), but min increment is on
+the order of 10 ns. Accuracy is +/- 90 ppm.
+
+#### `TIME_FROM_SYNC_PULSE_IN`
+
+A free running counter synced to the `SYNC_PULSE_IN` input counts seconds (# of
+pulses) and nanoseconds since OS1 turn on. If `multipurpose_io_mode` is set to
+`INPUT_NMEA_UART` then the seconds register jumps to time extracted from a NMEA
+`$GPRMC` message read on the `multipurpose_io` port. Reported at ns resolution
+(both a second and nanosecond register in every UDP packet), but min increment
+is on the order of 10 ns. Accuracy is +/- 1 s from a perfect `SYNC_PULSE_IN`
+source.
+
+#### `TIME_FROM_PTP_1588`
+
+Synchronize with an external PTP master. A monotonically increasing counter
+that will begin counting seconds and nanoseconds since startup. As soon as a
+1588 sync event happens, the time will be updated to seconds and nanoseconds
+since 1970. The counter must always count forward in time. If another 1588 sync
+event happens the counter will either jump forward to match the new time, or
+slow itself down. It is reported at ns resolution (there is both a second and
+nanosecond register in every UDP packet), but the minimum increment
+varies. Accuracy is +/- <50 us from the 1588 master.
+
+#### `TIME_FROM_ROS_RECEPTION`
+
+Data are stamped with the ROS time when they are received. The inherent latency
+between when the data were sampled by the LiDAR and when the data were received
+by this ROS node is not modelled. This approach may be acceptable to get up and
+running quickly or for static applications. However, for mobile robots,
+particularly those traveling at higher speeds, it is not recommended to use
+this `timestamp_mode`. When running in this mode, the on-LiDAR `timestamp_mode`
+will not be set by this driver.
 
 ## Extensions
 

--- a/README.md
+++ b/README.md
@@ -38,17 +38,18 @@ See design doc in `design/*` directory [here](ros2_ouster/design/design_doc.md).
 | `reset`           | std_srvs/Empty          | Reset the sensor's connection     |
 | `GetMetadata`     | ouster_msgs/GetMetadata | Get information about the sensor  |
 
-| Parameter                | Type    | Description                                                          |
-|--------------------------|---------|----------------------------------------------------------------------|
-| `lidar_ip`               | String  | IP of lidar (ex. 10.5.5.87)                                          |
-| `computer_ip`            | String  | IP of computer to get data (ex. 10.5.5.1)                            |
-| `lidar_mode`             | String  | Mode of data capture, default `512x10`                               |
-| `imu_port`               | int     | Port of IMU data, default 7503                                       |
-| `lidar_port`             | int     | Port of laser data, default 7502                                     |
-| `sensor_frame`           | String  | TF frame of sensor, default `laser_sensor_frame`                     |
-| `laser_frame`            | String  | TF frame of laser data, default `laser_data_frame`                   |
-| `imu_frame`              | String  | TF frame of imu data, default `imu_data_frame`                       |
-| `use_system_default_qos` | bool    | Publish data with default QoS for rosbag2 recording, default `False` |
+| Parameter                | Type    | Description                                                            |
+|--------------------------|---------|------------------------------------------------------------------------|
+| `lidar_ip`               | String  | IP of lidar (ex. 10.5.5.87)                                            |
+| `computer_ip`            | String  | IP of computer to get data (ex. 10.5.5.1)                              |
+| `lidar_mode`             | String  | Mode of data capture, default `512x10`                                 |
+| `imu_port`               | int     | Port of IMU data, default 7503                                         |
+| `lidar_port`             | int     | Port of laser data, default 7502                                       |
+| `sensor_frame`           | String  | TF frame of sensor, default `laser_sensor_frame`                       |
+| `laser_frame`            | String  | TF frame of laser data, default `laser_data_frame`                     |
+| `imu_frame`              | String  | TF frame of imu data, default `imu_data_frame`                         |
+| `use_system_default_qos` | bool    | Publish data with default QoS for rosbag2 recording, default `False`   |
+| `timestamp_mode`         | String  | Method used to timestamp measurements, default `TIME_FROM_INTERNAL_OSC`|
 
 </center>
 

--- a/ouster_msgs/msg/Metadata.msg
+++ b/ouster_msgs/msg/Metadata.msg
@@ -1,5 +1,6 @@
 string hostname
 string lidar_mode
+string timestamp_mode
 float64[] beam_azimuth_angles
 float64[] beam_altitude_angles
 float64[] imu_to_sensor_transform

--- a/ouster_msgs/package.xml
+++ b/ouster_msgs/package.xml
@@ -5,6 +5,7 @@
   <version>0.1.0</version>
   <description>ROS2 messages for ouster lidar driver</description>
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
+  <maintainer email="tom@boxrobotics.ai">Tom Panzarella</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/ros2_ouster/include/ros2_ouster/OS1/processors/image_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/image_processor.hpp
@@ -173,10 +173,10 @@ public:
    * @brief Process method to create images
    * @param data the packet data
    */
-  bool process(uint8_t * data) override
+  bool process(uint8_t * data, uint64_t override_ts) override
   {
     OSImageIt it = _information_image.begin();
-    _batch_and_publish(data, it);
+    _batch_and_publish(data, it, override_ts);
     return true;
   }
 
@@ -207,7 +207,7 @@ private:
   rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Image>::SharedPtr _intensity_image_pub;
   rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Image>::SharedPtr _range_image_pub;
   rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Image>::SharedPtr _noise_image_pub;
-  std::function<void(const uint8_t *, OSImageIt)> _batch_and_publish;
+  std::function<void(const uint8_t *, OSImageIt, uint64_t)> _batch_and_publish;
   rclcpp_lifecycle::LifecycleNode::SharedPtr _node;
   sensor_msgs::msg::Image _reflectivity_image;
   sensor_msgs::msg::Image _intensity_image;

--- a/ros2_ouster/include/ros2_ouster/OS1/processors/imu_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/imu_processor.hpp
@@ -65,10 +65,10 @@ public:
    * @brief Process method to create imu
    * @param data the packet data
    */
-  bool process(uint8_t * data) override
+  bool process(uint8_t * data, uint64_t override_ts) override
   {
     if (_pub->get_subscription_count() > 0 && _pub->is_activated()) {
-      _pub->publish(ros2_ouster::toMsg(data, _frame));
+      _pub->publish(ros2_ouster::toMsg(data, _frame, override_ts));
     }
     return true;
   }

--- a/ros2_ouster/include/ros2_ouster/OS1/processors/pointcloud_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/pointcloud_processor.hpp
@@ -87,10 +87,10 @@ public:
    * @brief Process method to create pointcloud
    * @param data the packet data
    */
-  bool process(uint8_t * data) override
+  bool process(uint8_t * data, uint64_t override_ts) override
   {
     pcl::PointCloud<point_os::PointOS>::iterator it = _cloud->begin();
-    _batch_and_publish(data, it);
+    _batch_and_publish(data, it, override_ts);
     return true;
   }
 
@@ -111,7 +111,8 @@ public:
   }
 
 private:
-  std::function<void(const uint8_t *, pcl::PointCloud<point_os::PointOS>::iterator)>
+  std::function<void(const uint8_t *,
+    pcl::PointCloud<point_os::PointOS>::iterator, uint64_t)>
   _batch_and_publish;
   rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::PointCloud2>::SharedPtr _pub;
   std::shared_ptr<pcl::PointCloud<point_os::PointOS>> _cloud;

--- a/ros2_ouster/include/ros2_ouster/OS1/processors/scan_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/scan_processor.hpp
@@ -98,10 +98,10 @@ public:
    * @brief Process method to create scan
    * @param data the packet data
    */
-  bool process(uint8_t * data) override
+  bool process(uint8_t * data, uint64_t override_ts) override
   {
     OSScanIt it = _aggregated_scans.begin();
-    _batch_and_publish(data, it);
+    _batch_and_publish(data, it, override_ts);
     return true;
   }
 
@@ -123,7 +123,7 @@ public:
 
 private:
   rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::LaserScan>::SharedPtr _pub;
-  std::function<void(const uint8_t *, OSScanIt)> _batch_and_publish;
+  std::function<void(const uint8_t *, OSScanIt, uint64_t)> _batch_and_publish;
   std::shared_ptr<pcl::PointCloud<scan_os::ScanOS>> _cloud;
   rclcpp_lifecycle::LifecycleNode::SharedPtr _node;
   std::vector<double> _xyz_lut;

--- a/ros2_ouster/include/ros2_ouster/conversions.hpp
+++ b/ros2_ouster/include/ros2_ouster/conversions.hpp
@@ -67,6 +67,7 @@ inline ouster_msgs::msg::Metadata toMsg(const ros2_ouster::Metadata & mdata)
   ouster_msgs::msg::Metadata msg;
   msg.hostname = mdata.hostname;
   msg.lidar_mode = mdata.mode;
+  msg.timestamp_mode = mdata.timestamp_mode;
   msg.beam_azimuth_angles = mdata.beam_azimuth_angles;
   msg.beam_altitude_angles = mdata.beam_altitude_angles;
   msg.imu_to_sensor_transform = mdata.imu_to_sensor_transform;

--- a/ros2_ouster/include/ros2_ouster/conversions.hpp
+++ b/ros2_ouster/include/ros2_ouster/conversions.hpp
@@ -108,7 +108,8 @@ inline geometry_msgs::msg::TransformStamped toMsg(
  */
 inline sensor_msgs::msg::Imu toMsg(
   const uint8_t * buf,
-  const std::string & frame)
+  const std::string & frame,
+  uint64_t override_ts = 0)
 {
   const double standard_g = 9.80665;
   sensor_msgs::msg::Imu m;
@@ -117,8 +118,8 @@ inline sensor_msgs::msg::Imu toMsg(
   m.orientation.z = 0;
   m.orientation.w = 1;
 
-  rclcpp::Time t(OS1::imu_gyro_ts(buf));
-  m.header.stamp = t;
+  m.header.stamp = override_ts == 0 ?
+    rclcpp::Time(OS1::imu_gyro_ts(buf)) : rclcpp::Time(override_ts);
   m.header.frame_id = frame;
 
   m.linear_acceleration.x = OS1::imu_la_x(buf) * standard_g;

--- a/ros2_ouster/include/ros2_ouster/interfaces/configuration.hpp
+++ b/ros2_ouster/include/ros2_ouster/interfaces/configuration.hpp
@@ -28,6 +28,7 @@ struct Configuration
   int imu_port;
   int lidar_port;
   std::string lidar_mode;
+  std::string timestamp_mode;
 };
 
 }  // namespace ros2_ouster

--- a/ros2_ouster/include/ros2_ouster/interfaces/data_processor_interface.hpp
+++ b/ros2_ouster/include/ros2_ouster/interfaces/data_processor_interface.hpp
@@ -46,8 +46,10 @@ public:
   /**
    * @brief Process a packet with the lidar-specific APIs
    * @param data packet input
+   * @param override_ts Timestamp in nanos to use to override the ts in the
+   *                    packet data. To use the packet data, pass as 0.
    */
-  virtual bool process(uint8_t * data) = 0;
+  virtual bool process(uint8_t * data, uint64_t override_ts = 0) = 0;
 
   /**
    * @brief Activating processor from lifecycle state transitions

--- a/ros2_ouster/include/ros2_ouster/interfaces/metadata.hpp
+++ b/ros2_ouster/include/ros2_ouster/interfaces/metadata.hpp
@@ -41,6 +41,7 @@ struct Metadata
   std::string sn;
   std::string fw_rev;
   std::string mode;
+  std::string timestamp_mode;
   std::vector<double> beam_azimuth_angles;
   std::vector<double> beam_altitude_angles;
   std::vector<double> imu_to_sensor_transform;

--- a/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
+++ b/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
@@ -138,6 +138,7 @@ private:
   std::unique_ptr<tf2_ros::StaticTransformBroadcaster> _tf_b;
 
   bool _use_system_default_qos;
+  bool _use_ros_time;
 };
 
 }  // namespace ros2_ouster

--- a/ros2_ouster/package.xml
+++ b/ros2_ouster/package.xml
@@ -5,6 +5,7 @@
   <version>0.1.0</version>
   <description>ROS2 Drivers for the Ouster OS-1 Lidar</description>
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
+  <maintainer email="tom@boxrobotics.ai">Tom Panzarella</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/ros2_ouster/params/os1.yaml
+++ b/ros2_ouster/params/os1.yaml
@@ -13,3 +13,12 @@ ouster_driver:
     # for production but default QoS is needed for rosbag.
     # See: https://github.com/ros2/rosbag2/issues/125
     use_system_default_qos: False
+
+    # Set the method used to timestamp measurements.
+    # Valid modes are:
+    #
+    #   TIME_FROM_INTERNAL_OSC
+    #   TIME_FROM_SYNC_PULSE_IN
+    #   TIME_FROM_PTP_1588
+    #
+    timestamp_mode: TIME_FROM_INTERNAL_OSC

--- a/ros2_ouster/params/os1.yaml
+++ b/ros2_ouster/params/os1.yaml
@@ -20,5 +20,9 @@ ouster_driver:
     #   TIME_FROM_INTERNAL_OSC
     #   TIME_FROM_SYNC_PULSE_IN
     #   TIME_FROM_PTP_1588
+    #   TIME_FROM_ROS_RECEPTION
+    #
+    # (See this project's README and/or the Ouster Software Guide for more
+    # information).
     #
     timestamp_mode: TIME_FROM_INTERNAL_OSC

--- a/ros2_ouster/src/OS1/OS1_sensor.cpp
+++ b/ros2_ouster/src/OS1/OS1_sensor.cpp
@@ -49,9 +49,17 @@ void OS1Sensor::configure(const ros2_ouster::Configuration & config)
     exit(-1);
   }
 
+  if (!OS1::timestamp_mode_of_string(config.timestamp_mode)) {
+    throw ros2_ouster::OusterDriverException(
+            std::string(
+              "Invalid timestamp mode %s!", config.timestamp_mode.c_str()));
+    exit(-1);
+  }
+
   _ouster_client = OS1::init_client(
     config.lidar_ip, config.computer_ip,
     OS1::lidar_mode_of_string(config.lidar_mode),
+    OS1::timestamp_mode_of_string(config.timestamp_mode),
     config.lidar_port, config.imu_port);
 
   if (!_ouster_client) {
@@ -102,7 +110,7 @@ ros2_ouster::Metadata OS1Sensor::getMetadata()
   if (_ouster_client) {
     return OS1::parse_metadata(OS1::get_metadata(*_ouster_client));
   } else {
-    return {"UNKNOWN", "UNKNOWN", "UNNKOWN", "UNNKOWN",
+    return {"UNKNOWN", "UNKNOWN", "UNNKOWN", "UNNKOWN", "UNKNOWN",
       {}, {}, {}, {}, 7503, 7502};
   }
 }

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -71,7 +71,8 @@ void OusterDriver<SensorT>::onConfigure()
   lidar_config.timestamp_mode = get_parameter("timestamp_mode").as_string();
   if (lidar_config.timestamp_mode == "TIME_FROM_ROS_RECEPTION") {
     RCLCPP_WARN(this->get_logger(),
-      "Using TIME_FROM_ROS_RECEPTION to stamp data with unmodelled latency!");
+      "Using TIME_FROM_ROS_RECEPTION to stamp data with ROS time on "
+      "reception. This has unmodelled latency!");
     _use_ros_time = true;
   } else {
     _use_ros_time = false;

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -201,9 +201,11 @@ void OusterDriver<SensorT>::processData()
     if (packet_data) {
       std::pair<DataProcessorMapIt, DataProcessorMapIt> key_its;
       key_its = _data_processors.equal_range(state);
+      uint64_t override_ts =
+        this->_use_ros_time ? this->now().nanoseconds() : 0;
+
       for (DataProcessorMapIt it = key_its.first; it != key_its.second; it++) {
-        it->second->process(packet_data,
-          this->_use_ros_time ? this->now().nanoseconds() : 0);
+        it->second->process(packet_data, override_ts);
       }
     }
   } catch (const OusterDriverException & e) {

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -38,6 +38,8 @@ OusterDriver<SensorT>::OusterDriver(const rclcpp::NodeOptions & options)
   this->declare_parameter("imu_port", 7503);
   this->declare_parameter("lidar_port", 7502);
   this->declare_parameter("lidar_mode", std::string("512x10"));
+  this->declare_parameter(
+    "timestamp_mode", std::string("TIME_FROM_INTERNAL_OSC"));
   this->declare_parameter("sensor_frame", std::string("laser_sensor_frame"));
   this->declare_parameter("laser_frame", std::string("laser_data_frame"));
   this->declare_parameter("imu_frame", std::string("imu_data_frame"));
@@ -66,6 +68,7 @@ void OusterDriver<SensorT>::onConfigure()
   lidar_config.imu_port = get_parameter("imu_port").as_int();
   lidar_config.lidar_port = get_parameter("lidar_port").as_int();
   lidar_config.lidar_mode = get_parameter("lidar_mode").as_string();
+  lidar_config.timestamp_mode = get_parameter("timestamp_mode").as_string();
 
   _laser_sensor_frame = get_parameter("sensor_frame").as_string();
   _laser_data_frame = get_parameter("laser_frame").as_string();
@@ -217,6 +220,7 @@ void OusterDriver<SensorT>::resetService(
   lidar_config.imu_port = get_parameter("imu_port").as_int();
   lidar_config.lidar_port = get_parameter("lidar_port").as_int();
   lidar_config.lidar_mode = get_parameter("lidar_mode").as_string();
+  lidar_config.timestamp_mode = get_parameter("timestamp_mode").as_string();
   _sensor->reset(lidar_config);
 }
 


### PR DESCRIPTION
The on-LiDAR `timestamp_mode` can now be set in the config file. Additionally,
its state is fedback in the `GetMetadata` service.

I HIL-tested these changes via visual inspection and everything seems to
be working correctly. I see that in #10 there is a plan add some
automated testing. I think this is a *very good* idea. I'll add some comments
to that issue shortly.

Closes: #34