### PR TITLE
Improving jitter through the driver and middleware stack for data processors

### DIFF
--- a/ros2_ouster/include/ros2_ouster/OS1/processors/pointcloud_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/pointcloud_processor.hpp
@@ -17,6 +17,7 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "rclcpp/qos.hpp"
 
@@ -69,9 +70,9 @@ public:
       {
         if (_pub->get_subscription_count() > 0 && _pub->is_activated()) {
           auto msg_ptr =
-            std::make_unique<sensor_msgs::msg::PointCloud2>(
-              std::move(ros2_ouster::toMsg(
-                *_cloud, std::chrono::nanoseconds(scan_ts), _frame)));
+          std::make_unique<sensor_msgs::msg::PointCloud2>(
+            std::move(ros2_ouster::toMsg(
+              *_cloud, std::chrono::nanoseconds(scan_ts), _frame)));
           _pub->publish(std::move(msg_ptr));
         }
       });

--- a/ros2_ouster/include/ros2_ouster/OS1/processors/pointcloud_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/pointcloud_processor.hpp
@@ -68,9 +68,11 @@ public:
       [&](uint64_t scan_ts) mutable
       {
         if (_pub->get_subscription_count() > 0 && _pub->is_activated()) {
-          sensor_msgs::msg::PointCloud2 msg = ros2_ouster::toMsg(*_cloud,
-          std::chrono::nanoseconds(scan_ts), _frame);
-          _pub->publish(msg);
+          auto msg_ptr =
+            std::make_unique<sensor_msgs::msg::PointCloud2>(
+              std::move(ros2_ouster::toMsg(
+                *_cloud, std::chrono::nanoseconds(scan_ts), _frame)));
+          _pub->publish(std::move(msg_ptr));
         }
       });
   }

--- a/ros2_ouster/include/ros2_ouster/OS1/processors/scan_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/scan_processor.hpp
@@ -17,6 +17,7 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "rclcpp/qos.hpp"
 
@@ -80,10 +81,10 @@ public:
       {
         if (_pub->get_subscription_count() > 0 && _pub->is_activated()) {
           auto msg_ptr =
-            std::make_unique<sensor_msgs::msg::LaserScan>(
-              std::move(ros2_ouster::toMsg(
-                _aggregated_scans, std::chrono::nanoseconds(scan_ts),
-                _frame, _mdata, _ring)));
+          std::make_unique<sensor_msgs::msg::LaserScan>(
+            std::move(ros2_ouster::toMsg(
+              _aggregated_scans, std::chrono::nanoseconds(scan_ts),
+              _frame, _mdata, _ring)));
           _pub->publish(std::move(msg_ptr));
         }
       });

--- a/ros2_ouster/include/ros2_ouster/OS1/processors/scan_processor.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processors/scan_processor.hpp
@@ -79,9 +79,12 @@ public:
       [&](uint64_t scan_ts) mutable
       {
         if (_pub->get_subscription_count() > 0 && _pub->is_activated()) {
-          sensor_msgs::msg::LaserScan msg = ros2_ouster::toMsg(_aggregated_scans,
-          std::chrono::nanoseconds(scan_ts), _frame, _mdata, _ring);
-          _pub->publish(msg);
+          auto msg_ptr =
+            std::make_unique<sensor_msgs::msg::LaserScan>(
+              std::move(ros2_ouster::toMsg(
+                _aggregated_scans, std::chrono::nanoseconds(scan_ts),
+                _frame, _mdata, _ring)));
+          _pub->publish(std::move(msg_ptr));
         }
       });
   }


### PR DESCRIPTION
In both the `pointcloud_processor` and `scan_processor` (the latter is really insignificant) this patch has the driver give up ownership of the message at the time of data publishing. This allows for middleware optimizations to include the elimination of unnecessary copies. Several tests on my machine show order of magnitude jitter improvements through the driver + middleware stack both out-of-process and while running as a component to sub-millisecond levels. Here are some data:

**NOTE:** `msg_stamp` here is the time stamped on the message by the driver (so, how consistent is the LiDAR at delivering the data). `recv_stamp` here is the time received by a subscriber (so, how long spent in the driver and through the ROS2 middleware before a subscriber can work with the data). I'm using `TIME_FROM_ROS_RECEPTION` as my timestamp mode so I can truly measure time spent in the driver and ROS2 middleware and not worry about in-LiDAR or network latency.

Before this patch, here is what the data looked like for the pointcloud processor (these are for interprocess communication tests over 1,000 messages -- the effect is similar when run as a component):

![test-case-5_1024x10_raw_latency](https://user-images.githubusercontent.com/645771/80842159-e46b9100-8bce-11ea-815b-a29033dda0e9.png)

Here is a quantile plot of the same:

![test-case-5_1024x10_q_latency](https://user-images.githubusercontent.com/645771/80842171-ec2b3580-8bce-11ea-837e-b123403d845e.png)

Here are the end-to-end numbers for this same set of data (again, before this patch):

![test-case-5_1024x10_e2e_raw_latency](https://user-images.githubusercontent.com/645771/80842203-ffd69c00-8bce-11ea-94e3-791e2b4e5721.png)

![test-case-5_1024x10_e2e_q_latency](https://user-images.githubusercontent.com/645771/80842214-049b5000-8bcf-11ea-801d-4621241cd525.png)

Here is what the data look like with this patch:
(Not perfect, there is much more we can do, but significantly improved in terms of jitter)

![test-case-6_1024x10_raw_latency](https://user-images.githubusercontent.com/645771/80842254-1b41a700-8bcf-11ea-872b-b50778649fbe.png)

![test-case-6_1024x10_q_latency](https://user-images.githubusercontent.com/645771/80842261-20065b00-8bcf-11ea-88c3-820574e51b31.png)

![test-case-6_1024x10_e2e_raw_latency](https://user-images.githubusercontent.com/645771/80842271-25fc3c00-8bcf-11ea-87fc-714d8e651f97.png)

![test-case-6_1024x10_e2e_q_latency](https://user-images.githubusercontent.com/645771/80842278-2a285980-8bcf-11ea-8d1c-fdb6bdc97c8d.png)

In terms of the end-to-end numbers, prior to this patch, the median end-to-end pointcloud delivery latency was 18.164 ms, however, the median absolute deviation (MAD) was 4.256 ms. With this patch, the median latency was 23.706 ms, but the MAD was only .252 ms. So, the patch significantly lessens the jitter which makes the system more stable. We can always tune to lessen absolute latency. Indeed, in my setup, the DDS could be further tuned.

