### PR TITLE
Provides a simple way to selectively turn on/off data processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,8 @@ The `os1_proc_mask` parameter is set to a mask-like-string used to define the
 data processors that should be activated upon startup of the driver. This will
 determine the topics that are available for client applications to consume. The
 *de facto* reference for these values are defined in
-[processor_factories.hpp](ros2_ouster/include/ros2_ouster/OS1/processor_factories.hpp). Tuning
-this parameter properly can have a dramatic effect on application performance
-in terms of latency and jitter.
+[processor_factories.hpp](ros2_ouster/include/ros2_ouster/OS1/processor_factories.hpp). It
+is recommended to only use the processors that you require for your application.
 
 The available data processors are:
 
@@ -119,7 +118,7 @@ The available data processors are:
   reflectivitiy from a scan.
 - **PCL** Provides a point cloud encoding of a LiDAR scan
 - **IMU** Provides a data stream from the LiDAR's integral IMU
-- **SCAN** Provides a synthesized 2D LaserScan from the 3D LiDAR data
+- **SCAN** Provides a 2D LaserScan from the closest to 0-degree azimuth ring
 
 To construct a valid string for the `os1_proc_mask` parameter, join the tokens
 from above (in any combination) with the pipe character (`|`). For example,

--- a/README.md
+++ b/README.md
@@ -38,18 +38,19 @@ See design doc in `design/*` directory [here](ros2_ouster/design/design_doc.md).
 | `reset`           | std_srvs/Empty          | Reset the sensor's connection     |
 | `GetMetadata`     | ouster_msgs/GetMetadata | Get information about the sensor  |
 
-| Parameter                | Type    | Description                                                            |
-|--------------------------|---------|------------------------------------------------------------------------|
-| `lidar_ip`               | String  | IP of lidar (ex. 10.5.5.87)                                            |
-| `computer_ip`            | String  | IP of computer to get data (ex. 10.5.5.1)                              |
-| `lidar_mode`             | String  | Mode of data capture, default `512x10`                                 |
-| `imu_port`               | int     | Port of IMU data, default 7503                                         |
-| `lidar_port`             | int     | Port of laser data, default 7502                                       |
-| `sensor_frame`           | String  | TF frame of sensor, default `laser_sensor_frame`                       |
-| `laser_frame`            | String  | TF frame of laser data, default `laser_data_frame`                     |
-| `imu_frame`              | String  | TF frame of imu data, default `imu_data_frame`                         |
-| `use_system_default_qos` | bool    | Publish data with default QoS for rosbag2 recording, default `False`   |
-| `timestamp_mode`         | String  | Method used to timestamp measurements, default `TIME_FROM_INTERNAL_OSC`|
+| Parameter                | Type    | Description                                                                |
+|--------------------------|---------|----------------------------------------------------------------------------|
+| `lidar_ip`               | String  | IP of lidar (ex. 10.5.5.87)                                                |
+| `computer_ip`            | String  | IP of computer to get data (ex. 10.5.5.1)                                  |
+| `lidar_mode`             | String  | Mode of data capture, default `512x10`                                     |
+| `imu_port`               | int     | Port of IMU data, default 7503                                             |
+| `lidar_port`             | int     | Port of laser data, default 7502                                           |
+| `sensor_frame`           | String  | TF frame of sensor, default `laser_sensor_frame`                           |
+| `laser_frame`            | String  | TF frame of laser data, default `laser_data_frame`                         |
+| `imu_frame`              | String  | TF frame of imu data, default `imu_data_frame`                             |
+| `use_system_default_qos` | bool    | Publish data with default QoS for rosbag2 recording, default `False`       |
+| `timestamp_mode`         | String  | Method used to timestamp measurements, default `TIME_FROM_INTERNAL_OSC`    |
+| `os1_proc_mask`          | String  | Mask encoding which data processors to activate, default `IMG|PCL|IMU|SCAN`|
 
 </center>
 
@@ -101,6 +102,32 @@ running quickly or for static applications. However, for mobile robots,
 particularly those traveling at higher speeds, it is not recommended to use
 this `timestamp_mode`. When running in this mode, the on-LiDAR `timestamp_mode`
 will not be set by this driver.
+
+### Parameterizing the Active Data Processors
+
+The `os1_proc_mask` parameter is set to a mask-like-string used to define the
+data processors that should be activated upon startup of the driver. This will
+determine the topics that are available for client applications to consume. The
+*de facto* reference for these values are defined in
+[processor_factories.hpp](ros2_ouster/include/ros2_ouster/OS1/processor_factories.hpp). Tuning
+this parameter properly can have a dramatic effect on application performance
+in terms of latency and jitter.
+
+The available data processors are:
+
+- **IMG** Provides 8-bit image topics encoding the noise, range, intensity, and
+  reflectivitiy from a scan.
+- **PCL** Provides a point cloud encoding of a LiDAR scan
+- **IMU** Provides a data stream from the LiDAR's integral IMU
+- **SCAN** Provides a synthesized 2D LaserScan from the 3D LiDAR data
+
+To construct a valid string for the `os1_proc_mask` parameter, join the tokens
+from above (in any combination) with the pipe character (`|`). For example,
+valid strings include but are not limited to: `IMG|PCL`, `IMG|PCL|IMU`, `PCL`,
+etc. The default value is `IMG|PCL|IMU|SCAN`.
+
+More details about data processors in the driver is provided in the [Additional
+Lidar Processing](#additional-lidar-processing) section below.
 
 ## Extensions
 

--- a/ros2_ouster/include/ros2_ouster/OS1/processor_factories.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/processor_factories.hpp
@@ -53,7 +53,7 @@ constexpr std::uint32_t OS1_DEFAULT_PROC_MASK =
  * @return The mask obtained from the parsed input string.
  */
 inline std::uint32_t
-to_proc_mask(const std::string & mask_str)
+toProcMask(const std::string & mask_str)
 {
   std::uint32_t mask = 0x0;
   auto tokens = ros2_ouster::split(mask_str, '|');

--- a/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
+++ b/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
@@ -143,6 +143,8 @@ private:
 
   bool _use_system_default_qos;
   bool _use_ros_time;
+
+  std::uint32_t _os1_proc_mask;
 };
 
 }  // namespace ros2_ouster

--- a/ros2_ouster/include/ros2_ouster/string_utils.hpp
+++ b/ros2_ouster/include/ros2_ouster/string_utils.hpp
@@ -1,0 +1,92 @@
+// Copyright 2020, Box Robotics, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS2_OUSTER__STRING_UTILS_HPP_
+#define ROS2_OUSTER__STRING_UTILS_HPP_
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace ros2_ouster
+{
+
+/**
+ * Trims whitespace from the left side of a string
+ *
+ * @param str The string to trim
+ * @param white Whitespace characters to erase
+ *
+ * @return A reference to the trimmed string
+ */
+inline std::string &
+ltrim(std::string & str, const std::string & white = "\t\n\v\f\r ")
+{
+  str.erase(0, str.find_first_not_of(white));
+  return str;
+}
+
+/**
+ * Trims whitespace from the right side of a string
+ *
+ * @param str The string to trim
+ * @param white Whitespace characters to erase
+ *
+ * @return A reference to the trimmed string
+ */
+inline std::string &
+rtrim(std::string & str, const std::string & white = "\t\n\v\f\r ")
+{
+  str.erase(str.find_last_not_of(white) + 1);
+  return str;
+}
+
+/**
+ * Trims whitespace from the front and back of a string
+ *
+ * @param str The string to trim
+ * @param white Whitespace characters to erase
+ *
+ * @return A reference to the trimmed string
+ */
+inline std::string &
+trim(std::string & str, const std::string & white = "\t\n\v\f\r ")
+{
+  return ros2_ouster::ltrim(ros2_ouster::rtrim(str, white), white);
+}
+
+/**
+ * Tokenizes a string based on a char delimeter
+ *
+ * @param[in] in The string to tokenize
+ * @param[in] delim The char delimeter to split the string on
+ *
+ * @return A vector of tokens
+ */
+inline std::vector<std::string>
+split(const std::string & in, char delim)
+{
+  std::vector<std::string> tokens;
+  std::string token;
+  std::istringstream ss(in);
+
+  while (std::getline(ss, token, delim)) {
+    tokens.push_back(token);
+  }
+
+  return tokens;
+}
+
+}  // namespace ros2_ouster
+
+#endif  // ROS2_OUSTER__STRING_UTILS_HPP_

--- a/ros2_ouster/params/os1.yaml
+++ b/ros2_ouster/params/os1.yaml
@@ -26,3 +26,27 @@ ouster_driver:
     # information).
     #
     timestamp_mode: TIME_FROM_INTERNAL_OSC
+
+    # Mask-like-string used to define the data processors that should be
+    # activated upon startup of the driver. This will determine the topics
+    # that are available for client applications to consume. The defacto
+    # reference for these values are defined in:
+    # `include/ros2_ouster/OS1/processor_factories.hpp`
+    #
+    # For convenience, the available data processors are:
+    #
+    # IMG   - Provides 8-bit image topics suitable for ML applications encoding
+    #         the noise, range, intensity, and reflectivity data from a scan
+    # PCL   - Provides a point cloud encoding of a LiDAR scan
+    # IMU   - Provides a data stream from the LiDARs integral IMU
+    # SCAN  - Provides a synthesized 2D LaserScan from the 3D LiDAR data
+    #
+    # To construct a valid string for this parameter join the tokens from above
+    # (in any combination) with the pipe character. For example, valid strings
+    # include (but are not limited to):
+    #
+    # IMG|PCL
+    # IMG|PCL|IMU|SCAN
+    # PCL
+    #
+    os1_proc_mask: IMG|PCL|IMU|SCAN

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -85,7 +85,7 @@ void OusterDriver::onConfigure()
   _use_system_default_qos = get_parameter("use_system_default_qos").as_bool();
 
   _os1_proc_mask =
-    ros2_ouster::to_proc_mask(get_parameter("os1_proc_mask").as_string());
+    ros2_ouster::toProcMask(get_parameter("os1_proc_mask").as_string());
 
   RCLCPP_INFO(this->get_logger(),
     "Connecting to sensor at %s.", lidar_config.lidar_ip.c_str());

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -48,6 +48,7 @@ OusterDriver::OusterDriver(
   this->declare_parameter("laser_frame", std::string("laser_data_frame"));
   this->declare_parameter("imu_frame", std::string("imu_data_frame"));
   this->declare_parameter("use_system_default_qos", false);
+  this->declare_parameter("os1_proc_mask", std::string("IMG|PCL|IMU|SCAN"));
 }
 
 OusterDriver::~OusterDriver() = default;
@@ -83,6 +84,9 @@ void OusterDriver::onConfigure()
   _imu_data_frame = get_parameter("imu_frame").as_string();
   _use_system_default_qos = get_parameter("use_system_default_qos").as_bool();
 
+  _os1_proc_mask =
+    ros2_ouster::to_proc_mask(get_parameter("os1_proc_mask").as_string());
+
   RCLCPP_INFO(this->get_logger(),
     "Connecting to sensor at %s.", lidar_config.lidar_ip.c_str());
   RCLCPP_INFO(this->get_logger(),
@@ -107,11 +111,11 @@ void OusterDriver::onConfigure()
       this->get_logger(), "Using system defaults QoS for sensor data");
     _data_processors = ros2_ouster::createProcessors(
       shared_from_this(), mdata, _imu_data_frame, _laser_data_frame,
-      rclcpp::SystemDefaultsQoS());
+      rclcpp::SystemDefaultsQoS(), _os1_proc_mask);
   } else {
     _data_processors = ros2_ouster::createProcessors(
       shared_from_this(), mdata, _imu_data_frame, _laser_data_frame,
-      rclcpp::SensorDataQoS());
+      rclcpp::SensorDataQoS(), _os1_proc_mask);
   }
 
   _tf_b = std::make_unique<tf2_ros::StaticTransformBroadcaster>(


### PR DESCRIPTION
@SteveMacenski and I have spoken a bit about how to make the data processors runtime selectable. We have contemplated several methods to include converting the data processors to plugins (using pluginlib), static polymorphic methods like CRTP, etc. However, Steve mentioned safety of runtime loadable code and also a desire to urge the community to contribute back any useful processors they may have -- i.e., if you want a new data processor in the driver, push it to us and we will compile it in. In that spirit, I think this PR can provide this capability to us and gives us some really nice side benefits. The primary feature is that we can selectively, through a parameter, choose which data processors are active at runtime.

This PR introduces the `os1_proc_mask` parameter. Its value is a string (that looks a lot like a bit mask that programmers are likely to be familiar with) that encodes which processors to activate when the driver starts. By default, we start all of the known data processors that are available today (no behavior change for current users). Setting the parameter in that way looks like (in YAML):

```
os1_proc_mask: IMG|PCL|IMU|SCAN
``` 

The available processors can be combined in any way. Valid strings include (but are not limited to): `IMG|PCL`, `IMG|PCL|IMU`, `PCL`, etc.

I have a secondary motivation for this PR and it is performance. In #41 we improved latency and jitter through the system by publishing the PointCloud as a `std::unique_ptr` rather than a reference which eliminates at least one expensive copy in the middleware. Running my same performance tests for consuming the PointCloud data and setting `os1_proc_mask` to `PCL` (i.e., the only active data processor is the PointCloud processor) we can reduce end-to-end latency (from the time the driver sees the data to the time an application receives the data ... so time in the driver and ROS2 middleware stack) by roughly 56%. Here are some plots.

(The syntax on these plots is the same as in #41 the blue trace is the latency and jitter of the LiDAR getting the data to the driver and the red trace is the latency and jitter between the driver and the consuming application):

![test-case-7_1024x10_raw_latency](https://user-images.githubusercontent.com/645771/82708854-45760a00-9c4d-11ea-8c2b-1492a11d1452.png)

And a quantile plot of the same:

![test-case-7_1024x10_q_latency](https://user-images.githubusercontent.com/645771/82708877-5757ad00-9c4d-11ea-860b-259f220fa103.png)

Here is what the end-to-end numbers look like (this is where this PR gives us a gain):

![test-case-7_1024x10_e2e_raw_latency](https://user-images.githubusercontent.com/645771/82708903-68a0b980-9c4d-11ea-9893-6e586e9d0534.png)

![test-case-7_1024x10_e2e_q_latency](https://user-images.githubusercontent.com/645771/82708912-6cccd700-9c4d-11ea-9bba-8d85adc9a5ea.png)

As was reported in #41 the improved median latency was 23.706 ms, and the MAD was 0.252 ms.  By turning off all data processors except the point cloud we now have a median end-to-end latency of 10.319 ms with a MAD of 0.183 ms. This is a ~56% reduction in latency through the driver and middleware stack.

There are more gains to be had in this driver and this PR provides a foundational piece to get us there.

