### PR TITLE
Fixed deprecations in launch file

### DIFF
--- a/ros2_ouster/launch/os1_launch.py
+++ b/ros2_ouster/launch/os1_launch.py
@@ -42,12 +42,12 @@ def generate_launch_description():
                                            description='FPath to the ROS2 parameters file to use.')
 
     driver_node = LifecycleNode(package='ros2_ouster',
-                                node_executable='ouster_driver',
-                                node_name=node_name,
+                                executable='ouster_driver',
+                                name=node_name,
                                 output='screen',
                                 emulate_tty=True,
                                 parameters=[parameter_file],
-                                node_namespace='/',
+                                namespace='/',
                                 )
 
     configure_event = EmitEvent(


### PR DESCRIPTION
Fixed some deprecation warnings related to the launch file. Prior, upon launch, an exemplary output looks like:

```
$ ros2 launch ros2_ouster os1_launch.py params_file:=${HOME}/.params2/os1.yaml
[INFO] [launch]: All log files can be found below /home/tpanzarella/.ros/log/2020-06-08-15-43-09-931214-jelly-4972
[INFO] [launch]: Default logging verbosity is set to INFO
/opt/ros/foxy/lib/python3.8/site-packages/launch_ros/actions/lifecycle_node.py:81: UserWarning: The parameter 'node_name' is deprecated, use 'name' instead
  warnings.warn("The parameter 'node_name' is deprecated, use 'name' instead")
/opt/ros/foxy/lib/python3.8/site-packages/launch_ros/actions/lifecycle_node.py:90: UserWarning: The parameter 'node_executable' is deprecated, use 'executable' instead
  super().__init__(name=name, **kwargs)
/opt/ros/foxy/lib/python3.8/site-packages/launch_ros/actions/node.py:181: UserWarning: The parameter 'node_namespace' is deprecated, use 'namespace' instead
  warnings.warn("The parameter 'node_namespace' is deprecated, use 'namespace' instead")
1591645390.073145 [0]       ros2: using network interface enp0s31f6 (udp/192.168.0.92) selected arbitrarily from: enp0s31f6, wlp3s0
[INFO] [ouster_driver-1]: process started with pid [4983]
[ouster_driver-1] 1591645390.118170 [0] ouster_dri: using network interface enp0s31f6 (udp/192.168.0.92) selected arbitrarily from: enp0s31f6, wlp3s0
[ouster_driver-1] [INFO] [1591645390.349303743] [ouster_driver]: Configuring Ouster driver node.
[ouster_driver-1] [INFO] [1591645390.349831607] [ouster_driver]: Connecting to sensor at 192.168.0.254.
[ouster_driver-1] [INFO] [1591645390.349950276] [ouster_driver]: Broadcasting data from sensor to 192.168.0.92.
[INFO] [launch.user]: [LifecycleLaunch] Ouster driver node is activating.
[ouster_driver-1] [INFO] [1591645390.408379182] [ouster_driver]: Activating Ouster driver node.
```

With this patch, exemplary output looks like:

```
$ ros2 launch ros2_ouster os1_launch.py params_file:=${HOME}/.params2/os1.yaml
[INFO] [launch]: All log files can be found below /home/tpanzarella/.ros/log/2020-06-08-15-49-57-405796-jelly-7309
[INFO] [launch]: Default logging verbosity is set to INFO
1591645797.497299 [0]       ros2: using network interface enp0s31f6 (udp/192.168.0.92) selected arbitrarily from: enp0s31f6, wlp3s0
[INFO] [ouster_driver-1]: process started with pid [7320]
[ouster_driver-1] 1591645797.522544 [0] ouster_dri: using network interface enp0s31f6 (udp/192.168.0.92) selected arbitrarily from: enp0s31f6, wlp3s0
[ouster_driver-1] [INFO] [1591645797.764282713] [ouster_driver]: Configuring Ouster driver node.
[ouster_driver-1] [WARN] [1591645797.764669737] [ouster_driver]: Using TIME_FROM_ROS_RECEPTION to stamp data with ROS time on reception. This has unmodelled latency!
[ouster_driver-1] [INFO] [1591645797.764802520] [ouster_driver]: Connecting to sensor at 192.168.0.254.
[ouster_driver-1] [INFO] [1591645797.764854084] [ouster_driver]: Broadcasting data from sensor to 192.168.0.92.
[INFO] [launch.user]: [LifecycleLaunch] Ouster driver node is activating.
[ouster_driver-1] [INFO] [1591645797.810213618] [ouster_driver]: Activating Ouster driver node.
```