### PR TITLE
Reorganizes in-memory data layout of point cloud

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,6 @@
+0.3.0 (YYYY-MM-DD)
+------------------
+* Reordered in-memory data of point cloud data processor to row-major order
+  (`#52 <https://github.com/SteveMacenski/ros2_ouster_drivers/issues/52>`_)
+* Start tracking changes in CHANGELOG at 0.3.0
+* Contributors: Steve Macenski, Tom Panzarella


### PR DESCRIPTION
This PR reorganizes the in-memory data layout of the point cloud to be consistent with the LiDAR geometry and in row-major order.

An analysis of this reorganization to include its motivation and validating the fix is available [here](https://nbviewer.jupyter.org/github/Box-Robotics/ros2-ouster-tools/blob/foxy-devel/ouster_perf/doc/notebooks/Ouster_Data_Layout.ipynb).

An analysis of the performance implications (which are **minimal**) is available [here](https://github.com/Box-Robotics/ros2-ouster-tools/blob/foxy-devel/ouster_perf/doc/foxy_perf.md#test-case-2).

Closes: #52 