### PR TITLE
Increases data processing loop rate from 1280 Hz to 2560 Hz

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,8 @@
 0.3.0 (YYYY-MM-DD)
 ------------------
+* Increased the rate at which the timer callback fires to process incoming data
+  from 1280 Hz to 2560 Hz.
+  (`#55 <https://github.com/SteveMacenski/ros2_ouster_drivers/issues/55>`_)
 * Reordered in-memory data of point cloud data processor to row-major order
   (`#52 <https://github.com/SteveMacenski/ros2_ouster_drivers/issues/52>`_)
 * Start tracking changes in CHANGELOG at 0.3.0

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -134,9 +134,11 @@ void OusterDriver::onActivate()
     it->second->onActivate();
   }
 
-  // speed of the Ouster lidars is 1280 hz
+  // Speed of the lidar is 1280 hz. We fire our timer event at 2x that rate to
+  // ensure we can process all of the incoming data in a timely manner.
+  // See: https://github.com/SteveMacenski/ros2_ouster_drivers/issues/55
   _process_timer = this->create_wall_timer(
-    781250ns, std::bind(&OusterDriver::processData, this));
+    390625ns, std::bind(&OusterDriver::processData, this));
 }
 
 void OusterDriver::onError()


### PR DESCRIPTION
Noteable jitter has been observed in processing the incoming LiDAR and IMU data when the hardware is run in `2048x10` and `1024x20` LiDAR modes. Increasing the rate at which the driver polls the incoming sockets for new data appears to resolve the problem with minimal structural changes to the software architecture of the driver. CPU utilization was profiled on a quad core (hyperthreaded) i7, and the affect seems both minimal and tolerable. No CPU profiling as been done on an embedded ARM device.

Closes #55 