### PR TITLE
Fix jsoncpp include/link interface

### DIFF
--- a/ros2_ouster/CMakeLists.txt
+++ b/ros2_ouster/CMakeLists.txt
@@ -53,7 +53,7 @@ ament_target_dependencies(${library_name}
 )
 
 target_link_libraries(${library_name}
-  jsoncpp
+  jsoncpp_lib
   ${PCL_LIBRARIES}
 )
 

--- a/ros2_ouster/include/ros2_ouster/OS1/OS1.hpp
+++ b/ros2_ouster/include/ros2_ouster/OS1/OS1.hpp
@@ -37,7 +37,7 @@
 #include "sys/socket.h"
 #include "sys/types.h"
 
-#include "jsoncpp/json/json.h"
+#include "json/json.h"
 #include "ros2_ouster/OS1/OS1_packet.hpp"
 #include "ros2_ouster/interfaces/metadata.hpp"
 


### PR DESCRIPTION
It appears that Ubuntu happens to put the jsoncpp headers at `/usr/include/jsoncpp/json/json.h`, but it doesn't appear that is necessarily common practice. By correcting the CMake interface for jsoncpp, the `/usr/include/jsoncpp` directory is added to the compiler's include directory search path, allowing the header reference to be changed to the correct path, `json/json.h`.

In particular, Fedora places the jsoncpp header at `/usr/include/json/json.h`. This change allows `ros2_ouster` to compile successfully on both platforms.