### PR TITLE
Set CMake build type to be Release by default

### DIFF
--- a/ros2_ouster/CMakeLists.txt
+++ b/ros2_ouster/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.5)
 project(ros2_ouster)
 
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)


### PR DESCRIPTION
Solves #63 . This sets the repo to built in Release mode by default. Note - this does not solve any underlying performance issues on why only release mode has full performance. 

[Reference](https://blog.kitware.com/cmake-and-the-default-build-type/)

Signed-off-by: Ryan Friedman <ryan_friedman@trimble.com>