### PR TITLE
Support set_udp_dest_auto

### DIFF
--- a/ros2_ouster/include/ros2_ouster/client/client.h
+++ b/ros2_ouster/include/ros2_ouster/client/client.h
@@ -45,6 +45,7 @@ namespace ouster {
      *
      * @param hostname hostname or ip of the sensor
      * @param udp_dest_host hostname or ip where the sensor should send data
+     * or "" for automatic detection of destination
      * @param lidar_port port on which the sensor will send lidar data
      * @param imu_port port on which the sensor will send imu data
      * @param timeout_sec how long to wait for the sensor to initialize

--- a/ros2_ouster/params/sensor.yaml
+++ b/ros2_ouster/params/sensor.yaml
@@ -1,7 +1,7 @@
 ouster_driver:
   ros__parameters:
-    lidar_ip: 10.5.5.96
-    computer_ip: 10.5.5.1
+    lidar_ip: "10.5.5.96"
+    computer_ip: "10.5.5.1"
     lidar_mode: "512x10"
     imu_port: 7503
     lidar_port: 7502

--- a/ros2_ouster/src/client/client.cpp
+++ b/ros2_ouster/src/client/client.cpp
@@ -566,9 +566,19 @@ std::shared_ptr<client> init_client(
   std::string res;
   bool success = true;
 
-  success &=
-    do_tcp_cmd(sock_fd, {"set_config_param", "udp_ip", udp_dest_host}, res);
-  success &= res == "set_config_param";
+  // If udp_dest_host is empty string, use automatic addressing with set_udp_dest_auto
+  if (udp_dest_host != "")
+  {
+    success &=
+      do_tcp_cmd(sock_fd, {"set_config_param", "udp_ip", udp_dest_host}, res);
+    success &= res == "set_config_param";
+  }
+  else
+  {
+    success &=
+      do_tcp_cmd(sock_fd, {"set_udp_dest_auto"}, res);
+      success &= res == "set_udp_dest_auto";
+  }
 
   success &= do_tcp_cmd(
     sock_fd,

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -99,10 +99,16 @@ void OusterDriver::onConfigure()
   RCLCPP_INFO(
     this->get_logger(),
     "Connecting to sensor at %s.", lidar_config.lidar_ip.c_str());
-  RCLCPP_INFO(
-    this->get_logger(),
-    "Sending data from sensor to %s.", lidar_config.computer_ip.c_str());
 
+  if (lidar_config.computer_ip == "") {
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Sending data from sensor to computer using automatic address detection");
+  }  else {
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Sending data from sensor to %s.", lidar_config.computer_ip.c_str());
+  }
   _reset_srv = this->create_service<std_srvs::srv::Empty>(
     "~/reset", std::bind(&OusterDriver::resetService, this, _1, _2, _3));
   _metadata_srv = this->create_service<ouster_msgs::srv::GetMetadata>(


### PR DESCRIPTION
Added support for `set_udp_dest_auto`
Added alternative configuration approach with ipv6 link local and automatic address detection. 

Note: I would rather show how to use the sensor hostname instead of finding the link local address, but I cannot get hostnames to work with my device with this library. 

Implements one of the boxes in #16 as requested by @rotu in #43 . 

Before merging, I'd like to get the hostname working and instead show how to use that in the README.
