### PR TITLE
Buffered packet processing

### DIFF
--- a/ros2_ouster/include/ros2_ouster/full_rotation_accumulator.hpp
+++ b/ros2_ouster/include/ros2_ouster/full_rotation_accumulator.hpp
@@ -35,7 +35,7 @@ public:
   FullRotationAccumulator(
     const ouster::sensor::sensor_info & mdata,
     const ouster::sensor::packet_format & pf)
-  : _pf(pf)
+  : _batchReady(false), _pf(pf), _packets_accumulated(0)
   {
     _batch = std::make_unique<ouster::ScanBatcher>(mdata.format.columns_per_frame, _pf);
     _ls = std::make_shared<ouster::LidarScan>(

--- a/ros2_ouster/include/ros2_ouster/interfaces/sensor_interface.hpp
+++ b/ros2_ouster/include/ros2_ouster/interfaces/sensor_interface.hpp
@@ -78,16 +78,18 @@ public:
   /**
    * @brief reading a lidar packet
    * @param state of the sensor
-   * @return the packet of data
+   * @param buf pointer to a buffer to hold the packet data. Must hold getPacketFormat().lidar_packet_size bytes.
+   * @return true if a packet was recieved, false otherwise
    */
-  virtual uint8_t * readLidarPacket(const ouster::sensor::client_state & state) = 0;
+  virtual bool readLidarPacket(const ouster::sensor::client_state & state, uint8_t * buf) = 0;
 
   /**
    * @brief reading an imu packet
    * @param state of the sensor
-   * @return the packet of data
+   * @param buf pointer to a buffer to hold the packet data. Must hold getPacketFormat().imu_packet_size bytes.
+   * @return true if a packet was recieved, false otherwise
    */
-  virtual uint8_t * readImuPacket(const ouster::sensor::client_state & state) = 0;
+  virtual bool readImuPacket(const ouster::sensor::client_state & state, uint8_t * buf) = 0;
 
   /**
    * @brief Get lidar sensor's metadata

--- a/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
+++ b/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
@@ -36,6 +36,8 @@
 #include "ros2_ouster/interfaces/data_processor_interface.hpp"
 #include "ros2_ouster/full_rotation_accumulator.hpp"
 
+#include "ros2_ouster/ringbuffer.hpp"
+
 namespace ros2_ouster
 {
 
@@ -154,12 +156,9 @@ private:
 
   std::uint32_t _proc_mask;
 
-  // Ringbuffer for raw received lidar and imu packets
-  std::vector<uint8_t> _lidar_packet_buf;
-  std::atomic<int> _lidar_packet_head; std::atomic<int> _lidar_packet_tail;
-  std::vector<uint8_t> _imu_packet_buf;
-  std::atomic<int> _imu_packet_head; std::atomic<int> _imu_packet_tail;
-  int _packet_buf_sz = 1024;
+  // Ringbuffers for raw received lidar and imu packets
+  std::unique_ptr<RingBuffer> _lidar_packet_buf;
+  std::unique_ptr<RingBuffer> _imu_packet_buf;
 
   // Threads and synchronization primitives for receiving and processing data
   std::thread _recv_thread;

--- a/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
+++ b/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
@@ -106,7 +106,7 @@ public:
 
 private:
   /**
-  * @brief Timer callback to process the UDP socket
+  * @brief Thread function to process data from the UDP socket
   */
   void receiveData();
 
@@ -137,6 +137,9 @@ private:
     const std::shared_ptr<ouster_msgs::srv::GetMetadata::Request> request,
     std::shared_ptr<ouster_msgs::srv::GetMetadata::Response> response);
 
+  /**
+  * @brief Thread function to process buffered packets that have been received from the sensor
+  */
   void processData();
 
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr _reset_srv;

--- a/ros2_ouster/include/ros2_ouster/ringbuffer.hpp
+++ b/ros2_ouster/include/ros2_ouster/ringbuffer.hpp
@@ -1,3 +1,4 @@
+// Copyright 2022, Mirko Kugelmeier
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -18,91 +19,96 @@
 
 namespace ros2_ouster
 {
+
+/**
+ * @class ros2_ouster::RingBuffer
+ * @brief A simple circular buffer implementation used for queued processing of incoming lidar / imu data
+ */
+class RingBuffer
+{
+public:
   /**
-   * @class ros2_ouster::RingBuffer
-   * @brief A simple circular buffer implementation used for queued processing of incoming lidar / imu data
+   * Create a new RingBuffer instance
+   * @param element_size The size (in bytes) of each element
+   * @param num_elements Number of maximum elements in the buffer.
    */
-  class RingBuffer
+  RingBuffer(std::size_t element_size, std::size_t num_elements)
+    : _element_size(element_size),
+      _num_elements(num_elements),
+      _head(0),
+      _tail(0),
+      _buf(new uint8_t[element_size * _num_elements])
+  {}
+
+  /**
+   * @brief Check whether there is any data to be read from the buffer at head()
+   * @return true if there are no elements in the buffer
+   */
+  bool empty()
   {
-  private:
-    // The size of each individual element in bytes and the max number of elements in the buffer
-    const std::size_t _element_size;
-    const std::size_t _num_elements;
+    return _head == _tail;
+  }
 
-    // Since the ringbuffer is used across threads that produce / consume the data, we use std::atomic for head and
-    // tail to prevent re-ordering of assignments to these variables
-    std::atomic<std::size_t> _head;
-    std::atomic<std::size_t> _tail;
+  /**
+   * @brief Check if the ringbuffer is full
+   * If the buffer is full, adding new data to it will overwrite or corrupt data at the head() position.
+   * This function is only safe to call in the producing thread, i.e. no calls to push() may occur simultaneously
+   * @return true if the buffer is full
+   */
+  bool full()
+  {
+    // Make sure we have a consistent value for the head index here.
+    // This makes sure we do not return 'false positives' when the buffer is not actually
+    // full due to a race on _head between the conditions.
+    bool head = _head;
 
-    // Defining the backing buffer as a unique_ptr gives us our dtor and correct copy/move semantics for free
-    std::unique_ptr<uint8_t[]> _buf;
+    // This ringbuffer implementation lets both head and tail loop twice around the actual number of
+    // elements in the buffer to encode the difference between the empty() and full() states. The
+    // buffer is full if head and tail refer to the same element but on different 'iterations'
+    // of the loop
+    return ((_tail * 2) % _num_elements) == head && head != _tail;
+  }
 
-  public:
-    /**
-     * Create a new RingBuffer instance
-     * @param element_size The size (in bytes) of each element
-     * @param num_elements Number of maximum elements in the buffer.
-     */
-    RingBuffer(std::size_t element_size, std::size_t num_elements)
-        : _element_size(element_size),
-          _num_elements(num_elements),
-          _head(0),
-          _tail(0),
-          _buf(new uint8_t[element_size * _num_elements])
-    {}
+  /// @return A pointer to the current element to read from
+  uint8_t * head()
+  {
+    return &_buf[(_head % _num_elements) * _element_size];
+  }
 
-    /**
-     * @brief Check whether there is any data to be read from the buffer at head()
-     * @return true if there are no elements in the buffer
-     */
-    bool empty()
-    {
-      return _head == _tail;
-    }
+  /// @return A pointer to the current element to write to
+  uint8_t * tail()
+  {
+    return &_buf[(_tail % _num_elements) * _element_size];
+  }
 
-    /**
-     * @brief Check if the ringbuffer is full
-     * If the buffer is full, adding new data to it will overwrite or corrupt data at the head() position.
-     * This function is only safe to call in the producing thread, i.e. no calls to push() may occur simultaneously
-     * @return true if the buffer is full
-     */
-    bool full()
-    {
-      // Make sure we have a consistent value for the head index here.
-      // This makes sure we do not return 'false positives' when the buffer is not actually full due to a race on
-      // _head between the conditions.
-      bool head = _head;
+  /// @brief Remove the current head element from the queue
+  void pop()
+  {
+    _head = (_head + 1) % (_num_elements * 2);
+  }
 
-      // This ringbuffer implementation lets both head and tail loop twice around the actual number of elements in the
-      // buffer to encode the difference between the empty() and full() states. The buffer is full if head and tail
-      // refer to the same element but on different 'iterations' of the loop
-      return ((_tail * 2) % _num_elements) == head && head != _tail;
-    }
+  /// @brief Add a new element (with data already filled at the location pointed to by tail())
+  /// to the buffer
+  void push()
+  {
+    _tail = (_tail + 1) % (_num_elements * 2);
+  }
 
-    /// @return A pointer to the current element to read from
-    uint8_t *head()
-    {
-      return &_buf[(_head % _num_elements) * _element_size];
-    }
+protected:
+  // The size of each individual element in bytes and the max number of elements in the buffer
+  const std::size_t _element_size;
+  const std::size_t _num_elements;
 
-    /// @return A pointer to the current element to write to
-    uint8_t *tail()
-    {
-      return &_buf[(_tail % _num_elements) * _element_size];
-    }
+  // Since the ringbuffer is used across threads that produce / consume the data, we use
+  // std::atomic for head and tail to prevent re-ordering of assignments to these variables
+  std::atomic<std::size_t> _head;
+  std::atomic<std::size_t> _tail;
 
-    /// @brief Remove the current head element from the queue
-    void pop()
-    {
-      _head = (_head + 1) % (_num_elements * 2);
-    }
+  // Defining the backing buffer as a unique_ptr gives us our dtor and correct copy/move
+  // semantics for free
+  std::unique_ptr<uint8_t[]> _buf;
+};
 
-    /// @brief Add a new element (with data already filled at the location pointed to by tail()) to the buffer
-    void push()
-    {
-      _tail = (_tail + 1) % (_num_elements * 2);
-    }
-  };
-}
+}  // namespace ros2_ouster
 
 #endif  // ROS2_OUSTER__RINGBUFFER_HPP_

--- a/ros2_ouster/include/ros2_ouster/ringbuffer.hpp
+++ b/ros2_ouster/include/ros2_ouster/ringbuffer.hpp
@@ -1,0 +1,108 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS2_OUSTER__RINGBUFFER_HPP_
+#define ROS2_OUSTER__RINGBUFFER_HPP_
+
+#include <atomic>
+#include <memory>
+
+namespace ros2_ouster
+{
+  /**
+   * @class ros2_ouster::RingBuffer
+   * @brief A simple circular buffer implementation used for queued processing of incoming lidar / imu data
+   */
+  class RingBuffer
+  {
+  private:
+    // The size of each individual element in bytes and the max number of elements in the buffer
+    const std::size_t _element_size;
+    const std::size_t _num_elements;
+
+    // Since the ringbuffer is used across threads that produce / consume the data, we use std::atomic for head and
+    // tail to prevent re-ordering of assignments to these variables
+    std::atomic<std::size_t> _head;
+    std::atomic<std::size_t> _tail;
+
+    // Defining the backing buffer as a unique_ptr gives us our dtor and correct copy/move semantics for free
+    std::unique_ptr<uint8_t[]> _buf;
+
+  public:
+    /**
+     * Create a new RingBuffer instance
+     * @param element_size The size (in bytes) of each element
+     * @param num_elements Number of maximum elements in the buffer.
+     */
+    RingBuffer(std::size_t element_size, std::size_t num_elements)
+        : _element_size(element_size),
+          _num_elements(num_elements),
+          _head(0),
+          _tail(0),
+          _buf(new uint8_t[element_size * _num_elements])
+    {}
+
+    /**
+     * @brief Check whether there is any data to be read from the buffer at head()
+     * @return true if there are no elements in the buffer
+     */
+    bool empty()
+    {
+      return _head == _tail;
+    }
+
+    /**
+     * @brief Check if the ringbuffer is full
+     * If the buffer is full, adding new data to it will overwrite or corrupt data at the head() position.
+     * This function is only safe to call in the producing thread, i.e. no calls to push() may occur simultaneously
+     * @return true if the buffer is full
+     */
+    bool full()
+    {
+      // Make sure we have a consistent value for the head index here.
+      // This makes sure we do not return 'false positives' when the buffer is not actually full due to a race on
+      // _head between the conditions.
+      bool head = _head;
+
+      // This ringbuffer implementation lets both head and tail loop twice around the actual number of elements in the
+      // buffer to encode the difference between the empty() and full() states. The buffer is full if head and tail
+      // refer to the same element but on different 'iterations' of the loop
+      return ((_tail * 2) % _num_elements) == head && head != _tail;
+    }
+
+    /// @return A pointer to the current element to read from
+    uint8_t *head()
+    {
+      return &_buf[(_head % _num_elements) * _element_size];
+    }
+
+    /// @return A pointer to the current element to write to
+    uint8_t *tail()
+    {
+      return &_buf[(_tail % _num_elements) * _element_size];
+    }
+
+    /// @brief Remove the current head element from the queue
+    void pop()
+    {
+      _head = (_head + 1) % (_num_elements * 2);
+    }
+
+    /// @brief Add a new element (with data already filled at the location pointed to by tail()) to the buffer
+    void push()
+    {
+      _tail = (_tail + 1) % (_num_elements * 2);
+    }
+  };
+}
+
+#endif  // ROS2_OUSTER__RINGBUFFER_HPP_

--- a/ros2_ouster/include/ros2_ouster/sensor.hpp
+++ b/ros2_ouster/include/ros2_ouster/sensor.hpp
@@ -68,16 +68,18 @@ public:
   /**
    * @brief reading a lidar packet
    * @param state of the sensor
-   * @return the packet of data
+   * @param buf pointer to a buffer to hold the packet data. Must hold getPacketFormat().lidar_packet_size bytes.
+   * @return true if a packet was recieved, false otherwise
    */
-  uint8_t * readLidarPacket(const ouster::sensor::client_state & state) override;
+  bool readLidarPacket(const ouster::sensor::client_state & state, uint8_t * buf) override;
 
   /**
    * @brief reading an imu packet
    * @param state of the sensor
-   * @return the packet of data
+   * @param buf pointer to a buffer to hold the packet data. Must hold getPacketFormat().imu_packet_size bytes.
+   * @return true if a packet was recieved, false otherwise
    */
-  uint8_t * readImuPacket(const ouster::sensor::client_state & state) override;
+  bool readImuPacket(const ouster::sensor::client_state & state, uint8_t * buf) override;
 
   /**
    * @brief Sets the metadata class variable
@@ -96,8 +98,6 @@ public:
 
 private:
   std::shared_ptr<ouster::sensor::client> _ouster_client;
-  std::vector<uint8_t> _lidar_packet;
-  std::vector<uint8_t> _imu_packet;
   ros2_ouster::Metadata _metadata{};
 };
 

--- a/ros2_ouster/include/ros2_ouster/sensor_tins.hpp
+++ b/ros2_ouster/include/ros2_ouster/sensor_tins.hpp
@@ -80,18 +80,20 @@ public:
   /**
    * @brief reading a lidar packet
    * @param state of the sensor
-   * @return the packet of data
+   * @param buf pointer to a buffer to hold the packet data. Must hold getPacketFormat().lidar_packet_size bytes.
+   * @return true if a packet was recieved, false otherwise
    */
-  uint8_t * readLidarPacket(
-    const ouster::sensor::client_state & state) override;
+  bool readLidarPacket(
+    const ouster::sensor::client_state & state, uint8_t * buf) override;
 
   /**
    * @brief reading an imu packet
    * @param state of the sensor
-   * @return the packet of data
+   * @param buf pointer to a buffer to hold the packet data. Must hold getPacketFormat().imu_packet_size bytes.
+   * @return true if a packet was recieved, false otherwise
    */
-  uint8_t * readImuPacket(
-    const ouster::sensor::client_state & state) override;
+  bool readImuPacket(
+    const ouster::sensor::client_state & state, uint8_t * buf) override;
 
   /**
    * @brief Sets the metadata class variable

--- a/ros2_ouster/src/client/lidar_scan.cpp
+++ b/ros2_ouster/src/client/lidar_scan.cpp
@@ -82,6 +82,10 @@ ScanBatcher::ScanBatcher(size_t w, const sensor::packet_format & pf)
 
 bool ScanBatcher::operator()(const uint8_t * packet_buf, LidarScan & ls)
 {
+  using row_view_t =
+    Eigen::Map<Eigen::Array<LidarScan::raw_t, Eigen::Dynamic,
+      Eigen::Dynamic, Eigen::RowMajor>>;
+
   if (ls.w != w || ls.h != h) {
     throw std::invalid_argument("unexpected scan dimensions");
   }
@@ -103,14 +107,29 @@ bool ScanBatcher::operator()(const uint8_t * packet_buf, LidarScan & ls)
     if (ls_write.frame_id != f_id) {
       // if not initializing with first packet
       if (ls_write.frame_id != -1) {
+        // zero out remaining missing columns
+        auto rows = h * LidarScan::N_FIELDS;
+        row_view_t{ls_write.data.data(), rows, w}
+        .block(0, next_m_id, rows, w - next_m_id)
+        .setZero();
+
         // finish the scan and notify callback
         std::swap(ls, ls_write);
         swapped = true;
-
-        ls_write.data.setZero();
       }
+
       // start new frame
+      next_m_id = 0;
       ls_write.frame_id = f_id;
+    }
+
+    // zero out missing columns if we jumped forward
+    if (m_id >= next_m_id) {
+      auto rows = h * LidarScan::N_FIELDS;
+      row_view_t{ls_write.data.data(), rows, w}
+      .block(0, next_m_id, rows, m_id - next_m_id)
+      .setZero();
+      next_m_id = m_id + 1;
     }
 
     ls_write.header(m_id) = {ts, encoder, status};

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -136,6 +136,9 @@ void OusterDriver::onConfigure()
   _tf_b = std::make_unique<tf2_ros::StaticTransformBroadcaster>(
     shared_from_this());
   broadcastStaticTransforms(_sensor->getMetadata());
+
+  _lidar_packet_buf.resize(_sensor->getPacketFormat().lidar_packet_size * _packet_buf_sz);
+  _imu_packet_buf.resize(_sensor->getPacketFormat().imu_packet_size * _packet_buf_sz);
 }
 
 void OusterDriver::onActivate()
@@ -145,11 +148,14 @@ void OusterDriver::onActivate()
     it->second->onActivate();
   }
 
-  // Speed of the lidar is 1280 hz. We fire our timer event at 2x that rate to
-  // ensure we can process all of the incoming data in a timely manner.
-  // See: https://github.com/SteveMacenski/ros2_ouster_drivers/issues/55
-  _process_timer = this->create_wall_timer(
-    390625ns, std::bind(&OusterDriver::processData, this));
+  _lidar_packet_head = 0;
+  _lidar_packet_tail = 0;
+  _imu_packet_head = 0;
+  _imu_packet_tail = 0;
+
+  _processing_active = true;
+  _process_thread = std::thread(std::bind(&OusterDriver::processData, this));
+  _recv_thread = std::thread(std::bind(&OusterDriver::receiveData, this));
 }
 
 void OusterDriver::onError()
@@ -158,8 +164,14 @@ void OusterDriver::onError()
 
 void OusterDriver::onDeactivate()
 {
-  _process_timer->cancel();
-  _process_timer.reset();
+  _processing_active = false;
+
+  if(_recv_thread.joinable())
+    _recv_thread.join();
+
+  _process_cond.notify_all();
+  if(_process_thread.joinable())
+    _process_thread.join();
 
   DataProcessorMapIt it;
   for (it = _data_processors.begin(); it != _data_processors.end(); ++it) {
@@ -177,9 +189,16 @@ void OusterDriver::onCleanup()
 
 void OusterDriver::onShutdown()
 {
-  _process_timer->cancel();
-  _process_timer.reset();
   _tf_b.reset();
+
+  _processing_active = false;
+
+  if(_recv_thread.joinable())
+    _recv_thread.join();
+
+  _process_cond.notify_all();
+  if(_process_thread.joinable())
+    _process_thread.join();
 
   DataProcessorMapIt it;
   _data_processors.clear();
@@ -202,44 +221,90 @@ void OusterDriver::broadcastStaticTransforms(
   }
 }
 
-void OusterDriver::processData()
-{
-  try {
-    ouster::sensor::client_state state = _sensor->get();
-    _lidar_packet_data = _sensor->readLidarPacket(state);
-    _imu_packet_data = _sensor->readImuPacket(state);
+void OusterDriver::processData() {
+  std::pair<DataProcessorMapIt, DataProcessorMapIt> key_lidar_its
+            = _data_processors.equal_range(ouster::sensor::client_state::LIDAR_DATA);
+  std::pair<DataProcessorMapIt, DataProcessorMapIt> key_imu_its
+      = _data_processors.equal_range(ouster::sensor::client_state::IMU_DATA);
+  auto pf = _sensor->getPacketFormat();
 
-    RCLCPP_DEBUG(
-      this->get_logger(),
-      "Retrieved packet with state: %s",
-      ros2_ouster::toString(state).c_str());
-
-    std::pair<DataProcessorMapIt, DataProcessorMapIt> key_its;
-
+  std::unique_lock<std::mutex> ringbuffer_guard(_ringbuffer_mutex);
+  while(_processing_active) {
+    // Wait for data in either the lidar or imu ringbuffer
+    _process_cond.wait(ringbuffer_guard, [this] (){
+      return (  (_lidar_packet_head != _lidar_packet_tail)
+              || (_imu_packet_head != _imu_packet_tail)
+              || !_processing_active);
+    });
+    ringbuffer_guard.unlock();
     uint64_t override_ts =
-      this->_use_ros_time ? this->now().nanoseconds() : 0;
+        this->_use_ros_time ? this->now().nanoseconds() : 0;
 
-    if (_lidar_packet_data) {
-      _full_rotation_accumulator->accumulate(_lidar_packet_data, override_ts);
+    // If we have data in the lidar buffer, process it
+    if(_lidar_packet_head != _lidar_packet_tail && _processing_active) {
+      uint8_t *data = _lidar_packet_buf.data() + _lidar_packet_head * pf.lidar_packet_size;
+      _lidar_packet_head = (_lidar_packet_head + 1) % _packet_buf_sz;
 
-      key_its = _data_processors.equal_range(ouster::sensor::client_state::LIDAR_DATA);
-
-      for (DataProcessorMapIt it = key_its.first; it != key_its.second; it++) {
-        it->second->process(_lidar_packet_data, override_ts);
+      _full_rotation_accumulator->accumulate(data, override_ts);
+      for (DataProcessorMapIt it = key_lidar_its.first; it != key_lidar_its.second; it++) {
+        it->second->process(data, override_ts);
       }
     }
 
-    if (_imu_packet_data) {
-      key_its = _data_processors.equal_range(ouster::sensor::client_state::IMU_DATA);
+    // If we have data in the imu buffer, process it
+    if(_imu_packet_head != _imu_packet_tail && _processing_active) {
+      uint8_t *data = _imu_packet_buf.data() + _imu_packet_head * pf.imu_packet_size;
+      _imu_packet_head = (_imu_packet_head + 1) % _packet_buf_sz;
+      key_imu_its = _data_processors.equal_range(ouster::sensor::client_state::IMU_DATA);
 
-      for (DataProcessorMapIt it = key_its.first; it != key_its.second; it++) {
-        it->second->process(_imu_packet_data, override_ts);
+      for (DataProcessorMapIt it = key_imu_its.first; it != key_imu_its.second; it++) {
+        it->second->process(data, override_ts);
       }
     }
-  } catch (const OusterDriverException & e) {
-    RCLCPP_WARN(
-      this->get_logger(),
-      "Failed to process packet with exception %s.", e.what());
+
+    ringbuffer_guard.lock();
+  }
+}
+
+void OusterDriver::receiveData()
+{
+  auto pf = _sensor->getPacketFormat();
+  while(_processing_active) {
+    try {
+      // Receive raw sensor data from the network. This blocks for some time until either data is received or timeout
+      ouster::sensor::client_state state = _sensor->get();
+      bool got_lidar = _sensor->readLidarPacket(state,
+                                                _lidar_packet_buf.data() + _lidar_packet_tail * pf.lidar_packet_size);
+      bool got_imu = _sensor->readImuPacket(state, _imu_packet_buf.data() + _imu_packet_tail * pf.imu_packet_size);
+
+      // If we got some data, update ringbuffer indices and signal processing thread
+      if (got_lidar || got_imu) {
+        _ringbuffer_mutex.lock();
+        if (got_lidar) {
+          _lidar_packet_tail = (_lidar_packet_tail + 1) % _packet_buf_sz;
+          if (_lidar_packet_tail == _lidar_packet_head)
+            RCLCPP_WARN(this->get_logger(), "Lidar buffer overrun!");
+        }
+
+        if (got_imu) {
+          _imu_packet_tail = (_imu_packet_tail + 1) % _packet_buf_sz;
+          if (_imu_packet_tail == _imu_packet_head)
+            RCLCPP_WARN(this->get_logger(), "IMU buffer overrun!");
+        }
+        _ringbuffer_mutex.unlock();
+        _process_cond.notify_all();
+      }
+
+
+      RCLCPP_DEBUG(
+          this->get_logger(),
+          "Retrieved packet with state: %s",
+          ros2_ouster::toString(state).c_str());
+    } catch (const OusterDriverException &e) {
+      RCLCPP_WARN(
+          this->get_logger(),
+          "Failed to process packet with exception %s.", e.what());
+    }
   }
 }
 

--- a/ros2_ouster/src/sensor.cpp
+++ b/ros2_ouster/src/sensor.cpp
@@ -28,8 +28,6 @@ Sensor::Sensor()
 Sensor::~Sensor()
 {
   _ouster_client.reset();
-  _lidar_packet.clear();
-  _imu_packet.clear();
 }
 
 void Sensor::reset(
@@ -90,8 +88,6 @@ void Sensor::configure(
   }
 
   setMetadata(config.lidar_port, config.imu_port, config.timestamp_mode);
-  _lidar_packet.resize(this->getPacketFormat().lidar_packet_size + 1);
-  _imu_packet.resize(this->getPacketFormat().imu_packet_size + 1);
 }
 
 ouster::sensor::client_state Sensor::get()
@@ -112,28 +108,28 @@ ouster::sensor::client_state Sensor::get()
   return state;
 }
 
-uint8_t * Sensor::readLidarPacket(const ouster::sensor::client_state & state)
+bool Sensor::readLidarPacket(const ouster::sensor::client_state & state, uint8_t * buf)
 {
   if (state & ouster::sensor::client_state::LIDAR_DATA &&
     ouster::sensor::read_lidar_packet(
-      *_ouster_client, _lidar_packet.data(),
+      *_ouster_client, buf,
       this->getPacketFormat()))
   {
-    return _lidar_packet.data();
+    return true;
   }
-  return nullptr;
+  return false;
 }
 
-uint8_t * Sensor::readImuPacket(const ouster::sensor::client_state & state)
+bool Sensor::readImuPacket(const ouster::sensor::client_state & state, uint8_t * buf)
 {
   if (state & ouster::sensor::client_state::IMU_DATA &&
     ouster::sensor::read_imu_packet(
-      *_ouster_client, _imu_packet.data(),
+      *_ouster_client, buf,
       this->getPacketFormat()))
   {
-    return _imu_packet.data();
+    return true;
   }
-  return nullptr;
+  return false;
 }
 
 void Sensor::setMetadata(

--- a/ros2_ouster/src/sensor_tins.cpp
+++ b/ros2_ouster/src/sensor_tins.cpp
@@ -128,21 +128,23 @@ ouster::sensor::client_state SensorTins::get()
   return _inferred_state;
 }
 
-uint8_t * SensorTins::readLidarPacket(const ouster::sensor::client_state & state)
+bool SensorTins::readLidarPacket(const ouster::sensor::client_state & state, uint8_t * buf)
 {
   if (state == ouster::sensor::client_state::LIDAR_DATA) {
-    return _lidar_packet.data();
+    std::memcpy(buf, _lidar_packet.data(), this->getPacketFormat().lidar_packet_size);
+    return true;
   } else {
-    return nullptr;
+    return false;
   }
 }
 
-uint8_t * SensorTins::readImuPacket(const ouster::sensor::client_state & state)
+bool SensorTins::readImuPacket(const ouster::sensor::client_state & state, uint8_t * buf)
 {
   if (state == ouster::sensor::client_state::IMU_DATA) {
-    return _imu_packet.data();
+    std::memcpy(buf, _imu_packet.data(), this->getPacketFormat().imu_packet_size);
+    return true;
   } else {
-    return nullptr;
+    return false;
   }
 }
 


### PR DESCRIPTION
Current blocking processing in OusterDriver::processData() causes packets to be lost if the processing of lidar data takes too much time, see Issue #96.

This PR splits the processing of lidar data into two seperate threads. Previously, the code receiving sensor data from the wire
was blocked by the lidar or imu processors, causing dataloss on slower systems.

* Modifies sensor interface so receiving functions get passed a pointer to a buffer to write their data to
* Implements ringbuffers for lidar and imu data in ouster_driver
* Splits processing into two seperate threads:
  * receiveData receives from the wire and fills ringbuffers
  * processData takes packets from the queue, assembles the lidar
    scan and runs the processors
* Threads are implemented as pure threads instead of ros timers,
  as timing inconsistencies for the receiver thread were also
  leading to data loss

