### PR TITLE
Add parameter to change azimuth window

### DIFF
--- a/ros2_ouster/include/ros2_ouster/client/client.h
+++ b/ros2_ouster/include/ros2_ouster/client/client.h
@@ -56,6 +56,7 @@ namespace ouster {
       const std::string & udp_dest_host,
       lidar_mode mode = MODE_UNSPEC,
       timestamp_mode ts_mode = TIME_FROM_UNSPEC,
+      AzimuthWindow azimuth_window = {0, 360000},
       int lidar_port = 0,
       int imu_port = 0,
       int timeout_sec = 60);

--- a/ros2_ouster/include/ros2_ouster/client/types.h
+++ b/ros2_ouster/include/ros2_ouster/client/types.h
@@ -286,6 +286,14 @@ namespace ouster {
     optional<NMEABaudRate> nmea_baud_rate_of_string(const std::string& s);
 
     /**
+     * Get azimuth window from string.
+     *
+     * @param string
+     * @return azimuth window corresponding to the string, or 0 on error
+     */
+    optional<AzimuthWindow> azimuth_window_of_string(const std::string& s);
+
+    /**
      * Get string representation of an Azimuth Window
      *
      * @param azimuth_window

--- a/ros2_ouster/include/ros2_ouster/interfaces/configuration.hpp
+++ b/ros2_ouster/include/ros2_ouster/interfaces/configuration.hpp
@@ -28,6 +28,7 @@ struct Configuration
   int imu_port;
   int lidar_port;
   std::string lidar_mode;
+  std::string azimuth_window;
   std::string timestamp_mode;
   std::string metadata_filepath;
   std::string ethernet_device;

--- a/ros2_ouster/params/driver_config.yaml
+++ b/ros2_ouster/params/driver_config.yaml
@@ -3,6 +3,7 @@ ouster_driver:
     lidar_ip: 10.5.5.96         
     computer_ip: 10.5.5.1    
     lidar_mode: "1024x10"
+    azimuth_window: "[70000,290000]"
     imu_port: 7503
     lidar_port: 7502
     sensor_frame: laser_sensor_frame

--- a/ros2_ouster/params/tins_driver_config.yaml
+++ b/ros2_ouster/params/tins_driver_config.yaml
@@ -3,7 +3,7 @@ ouster_driver:
     lidar_ip: 10.5.5.96 
     computer_ip: 10.5.5.1   
     lidar_mode: "1024x10"
-    azimuth_window: "[70000,290000]"
+    azimuth_window: "[0,360000]"
     imu_port: 7503
     lidar_port: 7502
     sensor_frame: laser_sensor_frame

--- a/ros2_ouster/params/tins_driver_config.yaml
+++ b/ros2_ouster/params/tins_driver_config.yaml
@@ -3,6 +3,7 @@ ouster_driver:
     lidar_ip: 10.5.5.96 
     computer_ip: 10.5.5.1   
     lidar_mode: "1024x10"
+    azimuth_window: "[70000,290000]"
     imu_port: 7503
     lidar_port: 7502
     sensor_frame: laser_sensor_frame

--- a/ros2_ouster/src/client/client.cpp
+++ b/ros2_ouster/src/client/client.cpp
@@ -547,6 +547,7 @@ std::shared_ptr<client> init_client(
   const std::string & hostname,
   const std::string & udp_dest_host,
   lidar_mode mode, timestamp_mode ts_mode,
+  AzimuthWindow azimuth_window,
   int lidar_port, int imu_port,
   int timeout_sec)
 {
@@ -601,6 +602,15 @@ std::shared_ptr<client> init_client(
   if (ts_mode) {
     success &= do_tcp_cmd(
       sock_fd, {"set_config_param", "timestamp_mode", to_string(ts_mode)},
+      res);
+    success &= res == "set_config_param";
+  }
+
+  // Setup Azimuth Window
+  if (azimuth_window) {
+    success &= do_tcp_cmd(
+      sock_fd,
+      {"set_config_param", "azimuth_window", to_string(azimuth_window)},
       res);
     success &= res == "set_config_param";
   }

--- a/ros2_ouster/src/client/client.cpp
+++ b/ros2_ouster/src/client/client.cpp
@@ -607,13 +607,11 @@ std::shared_ptr<client> init_client(
   }
 
   // Setup Azimuth Window
-  if (azimuth_window) {
-    success &= do_tcp_cmd(
-      sock_fd,
-      {"set_config_param", "azimuth_window", to_string(azimuth_window)},
-      res);
-    success &= res == "set_config_param";
-  }
+  success &= do_tcp_cmd(
+    sock_fd,
+    {"set_config_param", "azimuth_window", to_string(azimuth_window)},
+    res);
+  success &= res == "set_config_param";
 
   // wake up from STANDBY, if necessary
   success &= do_tcp_cmd(

--- a/ros2_ouster/src/client/types.cpp
+++ b/ros2_ouster/src/client/types.cpp
@@ -425,7 +425,7 @@ optional<AzimuthWindow> azimuth_window_of_string(const std::string& s)
   
   int res = sscanf(s.c_str(),"[%i,%i]",&p.first,&p.second);
 
-  return res == 2 ? p : nullopt;
+  return res == 2 ? make_optional<AzimuthWindow>(p) : nullopt;
 }
 
 std::string to_string(AzimuthWindow azimuth_window) 

--- a/ros2_ouster/src/client/types.cpp
+++ b/ros2_ouster/src/client/types.cpp
@@ -419,6 +419,15 @@ optional<NMEABaudRate> nmea_baud_rate_of_string(const std::string& s)
   return res == end ? nullopt : make_optional<NMEABaudRate>(res->first);
 }
 
+optional<AzimuthWindow> azimuth_window_of_string(const std::string& s) 
+{
+  AzimuthWindow p;
+  
+  int res = sscanf(s.c_str(),"[%i,%i]",&p.first,&p.second);
+
+  return res == 2 ? p : nullopt;
+}
+
 std::string to_string(AzimuthWindow azimuth_window) 
 {
   std::stringstream ss;

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -259,6 +259,7 @@ void OusterDriver::resetService(
   lidar_config.lidar_port = get_parameter("lidar_port").as_int();
   lidar_config.lidar_mode = get_parameter("lidar_mode").as_string();
   lidar_config.timestamp_mode = get_parameter("timestamp_mode").as_string();
+  lidar_config.azimuth_window = get_parameter("azimuth_window").as_string();
   _sensor->reset(lidar_config, shared_from_this());
 }
 

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -54,6 +54,7 @@ OusterDriver::OusterDriver(
   this->declare_parameter("lidar_port", 7502);
   this->declare_parameter("lidar_mode", std::string("512x10"));
   this->declare_parameter("timestamp_mode", std::string("TIME_FROM_INTERNAL_OSC"));
+  this->declare_parameter("azimuth_window", std::string("[0,360000]"));
 }
 
 OusterDriver::~OusterDriver() = default;
@@ -75,6 +76,7 @@ void OusterDriver::onConfigure()
   lidar_config.lidar_port = this->get_parameter("lidar_port").as_int();
   lidar_config.lidar_mode = this->get_parameter("lidar_mode").as_string();
   lidar_config.timestamp_mode = this->get_parameter("timestamp_mode").as_string();
+  lidar_config.azimuth_window = get_parameter("azimuth_window").as_string();
 
   // Deliberately retrieve the IP parameters in a try block without defaults, as
   // we cannot estimate a reasonable default IP address for the LiDAR/computer.

--- a/ros2_ouster/src/sensor.cpp
+++ b/ros2_ouster/src/sensor.cpp
@@ -61,6 +61,12 @@ void Sensor::configure(
     exit(-1);
   }
 
+  if (!ouster::sensor::azimuth_window_of_string(config.azimuth_window)) {
+    throw ros2_ouster::OusterDriverException(
+            "Invalid timestamp mode: " + config.azimuth_window);
+    exit(-1);
+  }
+
   // Report to the user whether automatic address detection is being used, and 
   // what the source / destination IPs are
   RCLCPP_INFO(
@@ -81,6 +87,7 @@ void Sensor::configure(
     config.computer_ip,
     ouster::sensor::lidar_mode_of_string(config.lidar_mode),
     ouster::sensor::timestamp_mode_of_string(config.timestamp_mode),
+    ouster::sensor::azimuth_window_of_string(config.azimuth_window),
     config.lidar_port,
     config.imu_port);
 

--- a/ros2_ouster/src/sensor.cpp
+++ b/ros2_ouster/src/sensor.cpp
@@ -87,7 +87,7 @@ void Sensor::configure(
     config.computer_ip,
     ouster::sensor::lidar_mode_of_string(config.lidar_mode),
     ouster::sensor::timestamp_mode_of_string(config.timestamp_mode),
-    ouster::sensor::azimuth_window_of_string(config.azimuth_window),
+    *ouster::sensor::azimuth_window_of_string(config.azimuth_window),
     config.lidar_port,
     config.imu_port);
 

--- a/ros2_ouster/src/sensor.cpp
+++ b/ros2_ouster/src/sensor.cpp
@@ -63,7 +63,7 @@ void Sensor::configure(
 
   if (!ouster::sensor::azimuth_window_of_string(config.azimuth_window)) {
     throw ros2_ouster::OusterDriverException(
-            "Invalid timestamp mode: " + config.azimuth_window);
+            "Invalid azimuth mode: " + config.azimuth_window);
     exit(-1);
   }
 


### PR DESCRIPTION
I don't think I am the only one using this configuration of the azimuth window. Previously we would set it through the web configurator and then it would be saved but on recent firmware versions it sometimes resets to 0-360 azimuth window which is unfortunate.

Therefore I made so that there is a parameter and the ROS driver sets this parameter as well.