### PR TITLE
Fix up warnings and errors from latest Rolling releases.

### DIFF
--- a/ros2_ouster/include/ros2_ouster/conversions.hpp
+++ b/ros2_ouster/include/ros2_ouster/conversions.hpp
@@ -29,7 +29,7 @@
 #include "sensor_msgs/msg/imu.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "tf2/LinearMath/Transform.h"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "ouster_msgs/msg/metadata.hpp"
 
 #include "ros2_ouster/client/client.h"

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -48,8 +48,8 @@ OusterDriver::OusterDriver(
   this->declare_parameter("proc_mask", std::string("IMG|PCL|IMU|SCAN"));
 
   // Declare parameters used across ALL _sensor_ implementations
-  this->declare_parameter("lidar_ip", std::string(""));
-  this->declare_parameter("computer_ip", std::string(""));
+  this->declare_parameter<std::string>("lidar_ip");
+  this->declare_parameter<std::string>("computer_ip");
   this->declare_parameter("imu_port", 7503);
   this->declare_parameter("lidar_port", 7502);
   this->declare_parameter("lidar_mode", std::string("512x10"));

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -48,8 +48,8 @@ OusterDriver::OusterDriver(
   this->declare_parameter("proc_mask", std::string("IMG|PCL|IMU|SCAN"));
 
   // Declare parameters used across ALL _sensor_ implementations
-  this->declare_parameter("lidar_ip");
-  this->declare_parameter("computer_ip");
+  this->declare_parameter("lidar_ip", std::string(""));
+  this->declare_parameter("computer_ip", std::string(""));
   this->declare_parameter("imu_port", 7503);
   this->declare_parameter("lidar_port", 7502);
   this->declare_parameter("lidar_mode", std::string("512x10"));


### PR DESCRIPTION
This cleans up two problems:

1.  rclcpp no longer accepts bare "declare_parameters" without
a type, so add an empty string by default.
2.  The tf2_geometry_msgs headers all should now use the .hpp
suffix, so fix that as well.

This should allow this package to build without warnings on the
buildfarm.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the failing builds, like in https://build.ros2.org/view/Rbin_uJ64/job/Rbin_uJ64__ros2_ouster__ubuntu_jammy_amd64__binary/