### PR TITLE
fix tf2_geometry_msgs include not found

### DIFF
--- a/ros2_ouster/include/ros2_ouster/conversions.hpp
+++ b/ros2_ouster/include/ros2_ouster/conversions.hpp
@@ -29,7 +29,12 @@
 #include "sensor_msgs/msg/imu.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "tf2/LinearMath/Transform.h"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#ifdef TF2_CPP_HEADERS
+  #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#else
+  #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#endif
+
 #include "ouster_msgs/msg/metadata.hpp"
 
 #include "ros2_ouster/client/client.h"


### PR DESCRIPTION
The commit #2d36cbd changed the include from .h to .hpp which at least for me on Galactic makes it not work. This is what i have found to be the recommended way to do it but testing on Humble would be required