### PR TITLE
Added default value for IPs

### DIFF
--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -48,8 +48,8 @@ OusterDriver::OusterDriver(
   this->declare_parameter("proc_mask", std::string("IMG|PCL|IMU|SCAN"));
 
   // Declare parameters used across ALL _sensor_ implementations
-  this->declare_parameter<std::string>("lidar_ip");
-  this->declare_parameter<std::string>("computer_ip");
+  this->declare_parameter<std::string>("lidar_ip","10.5.5.96");
+  this->declare_parameter<std::string>("computer_ip","10.5.5.1");
   this->declare_parameter("imu_port", 7503);
   this->declare_parameter("lidar_port", 7502);
   this->declare_parameter("lidar_mode", std::string("512x10"));


### PR DESCRIPTION
Hi,

I had the following situation:
With the `foxy` branch I couldn't make a OS0-128 work with firmware v2.x, so I used `ros2` branch.
However, I had the following error:

```
--- stderr: ros2_ouster                                
/home/jose/ros2_ws/src/ros2_ouster_drivers/ros2_ouster/src/ouster_driver.cpp: In constructor ‘ros2_ouster::OusterDriver::OusterDriver(std::unique_ptr<ros2_ouster::SensorInterface>, const rclcpp::NodeOptions&)’:
/home/jose/ros2_ws/src/ros2_ouster_drivers/ros2_ouster/src/ouster_driver.cpp:51:50: error: no matching function for call to ‘ros2_ouster::OusterDriver::declare_parameter<std::string>(const char [9])’
   51 |   this->declare_parameter<std::string>("lidar_ip");
      |                                                  ^
In file included from /opt/ros/foxy/include/rclcpp_lifecycle/lifecycle_node.hpp:935,
                 from /home/jose/ros2_ws/src/ros2_ouster_drivers/ros2_ouster/include/ros2_ouster/interfaces/lifecycle_interface.hpp:20,
                 from /home/jose/ros2_ws/src/ros2_ouster_drivers/ros2_ouster/src/ouster_driver.cpp:22:
/opt/ros/foxy/include/rclcpp_lifecycle/lifecycle_node_impl.hpp:135:1: note: candidate: ‘auto rclcpp_lifecycle::LifecycleNode::declare_parameter(const string&, const ParameterT&, const ParameterDescriptor&) [with ParameterT = std::__cxx11::basic_string<char>; std::string = std::__cxx11::basic_string<char>; rcl_interfaces::msg::ParameterDescriptor = rcl_interfaces::msg::ParameterDescriptor_<std::allocator<void> >]’
  135 | LifecycleNode::declare_parameter(
      | ^~~~~~~~~~~~~
/opt/ros/foxy/include/rclcpp_lifecycle/lifecycle_node_impl.hpp:135:1: note:   candidate expects 3 arguments, 1 provided
/home/jose/ros2_ws/src/ros2_ouster_drivers/ros2_ouster/src/ouster_driver.cpp:52:53: error: no matching function for call to ‘ros2_ouster::OusterDriver::declare_parameter<std::string>(const char [12])’
   52 |   this->declare_parameter<std::string>("computer_ip");
      |                                                     ^
In file included from /opt/ros/foxy/include/rclcpp_lifecycle/lifecycle_node.hpp:935,
                 from /home/jose/ros2_ws/src/ros2_ouster_drivers/ros2_ouster/include/ros2_ouster/interfaces/lifecycle_interface.hpp:20,
                 from /home/jose/ros2_ws/src/ros2_ouster_drivers/ros2_ouster/src/ouster_driver.cpp:22:
/opt/ros/foxy/include/rclcpp_lifecycle/lifecycle_node_impl.hpp:135:1: note: candidate: ‘auto rclcpp_lifecycle::LifecycleNode::declare_parameter(const string&, const ParameterT&, const ParameterDescriptor&) [with ParameterT = std::__cxx11::basic_string<char>; std::string = std::__cxx11::basic_string<char>; rcl_interfaces::msg::ParameterDescriptor = rcl_interfaces::msg::ParameterDescriptor_<std::allocator<void> >]’
  135 | LifecycleNode::declare_parameter(
      | ^~~~~~~~~~~~~
/opt/ros/foxy/include/rclcpp_lifecycle/lifecycle_node_impl.hpp:135:1: note:   candidate expects 3 arguments, 1 provided
make[2]: *** [CMakeFiles/ouster_driver_core.dir/build.make:76: CMakeFiles/ouster_driver_core.dir/src/ouster_driver.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:163: CMakeFiles/ouster_driver_core.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
---
Failed   <<< ros2_ouster [9.20s, exited with code 2]

Summary: 25 packages finished [11.5s]
  1 package failed: ros2_ouster
  1 package had stderr output: ros2_ouster
```

I've added a default value for each IP to avoid this error and use the `ros2` branch with ROS 2 Foxy and firmware v2.X