### PR TITLE
Fix for firmware 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ROS2 Ouster Drivers
 
-These are an implementation of ROS2 drivers for the Ouster lidar. This includes all models of the OS-x from 16 to 128 beams running the firmware 2.4.
+These are an implementation of ROS2 drivers for the Ouster lidar. This includes all models of the OS-x from 16 to 128 beams running the firmware 2.2-2.4.
 
 You can find a few videos looking over the sensor below. They both introduce the ROS1 driver but are extremely useful references regardless:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ROS2 Ouster Drivers
 
-These are an implementation of ROS2 drivers for the Ouster lidar. This includes all models of the OS-x from 16 to 128 beams running the firmware 2.1.
+These are an implementation of ROS2 drivers for the Ouster lidar. This includes all models of the OS-x from 16 to 128 beams running the firmware 2.4.
 
 You can find a few videos looking over the sensor below. They both introduce the ROS1 driver but are extremely useful references regardless:
 

--- a/ros2_ouster/src/client/client.cpp
+++ b/ros2_ouster/src/client/client.cpp
@@ -330,7 +330,7 @@ bool set_config_helper(
   };
 
   // set params
-  if (config.udp_dest && !set_param("udp_ip", config.udp_dest.value()))
+  if (config.udp_dest && !set_param("udp_dest", config.udp_dest.value()))
       return false;
 
   if (config.udp_port_lidar &&
@@ -570,7 +570,7 @@ std::shared_ptr<client> init_client(
   if (udp_dest_host != "")
   {
     success &=
-      do_tcp_cmd(sock_fd, {"set_config_param", "udp_ip", udp_dest_host}, res);
+      do_tcp_cmd(sock_fd, {"set_config_param", "udp_dest", udp_dest_host}, res);
     success &= res == "set_config_param";
   }
   else

--- a/ros2_ouster/src/client/client.cpp
+++ b/ros2_ouster/src/client/client.cpp
@@ -296,8 +296,8 @@ bool collect_metadata(client & cli, SOCKET sock_fd, chrono::seconds timeout)
 // (deprecated in 1.13)
 const std::array<std::pair<OperatingMode, std::string>, 2> auto_start_strings =
   {{
-    {OPERATING_NORMAL, "1"}, 
-    {OPERATING_STANDBY, "0"}
+    {OPERATING_NORMAL, "NORMAL"}, 
+    {OPERATING_STANDBY, "STANDBY"}
   }};
 
 static std::string auto_start_string(OperatingMode mode) 
@@ -353,8 +353,8 @@ bool set_config_helper(
   // "operating_mode" introduced in fw 2.0. use deprecated 'auto_start_flag'
   // to support 1.13
   if (config.operating_mode &&
-      !set_param("auto_start_flag",
-                  auto_start_string(config.operating_mode.value())))
+      !set_param("operating_mode",
+                  to_string(config.operating_mode.value())))
       return false;
 
   if (config.multipurpose_io_mode &&
@@ -607,7 +607,7 @@ std::shared_ptr<client> init_client(
 
   // wake up from STANDBY, if necessary
   success &= do_tcp_cmd(
-    sock_fd, {"set_config_param", "auto_start_flag", "1"}, res);
+    sock_fd, {"set_config_param", "operating_mode", "NORMAL"}, res);
   success &= res == "set_config_param";
 
   // reinitialize to activate new settings

--- a/ros2_ouster/src/client/types.cpp
+++ b/ros2_ouster/src/client/types.cpp
@@ -560,10 +560,11 @@ sensor_config parse_config(const Json::Value& root)
 
     // deprecated params from 1.13. set 2.0 configs appropriately
   if (!root["udp_dest"].empty()) config.udp_dest = root["udp_dest"].asString();
-  if (!root["auto_start_flag"].empty())
-    config.operating_mode = root["auto_start_flag"].asBool()
+  if (!root["operating_mode"].empty())
+    config.operating_mode = root["operating_mode"].asBool()
                                 ? sensor::OPERATING_NORMAL
                                 : sensor::OPERATING_STANDBY;
+
 
   return config;
 }

--- a/ros2_ouster/src/client/types.cpp
+++ b/ros2_ouster/src/client/types.cpp
@@ -559,7 +559,7 @@ sensor_config parse_config(const Json::Value& root)
     config.phase_lock_offset = root["phase_lock_offset"].asInt();
 
     // deprecated params from 1.13. set 2.0 configs appropriately
-  if (!root["udp_ip"].empty()) config.udp_dest = root["udp_ip"].asString();
+  if (!root["udp_dest"].empty()) config.udp_dest = root["udp_dest"].asString();
   if (!root["auto_start_flag"].empty())
     config.operating_mode = root["auto_start_flag"].asBool()
                                 ? sensor::OPERATING_NORMAL

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -110,7 +110,7 @@ void OusterDriver::onConfigure()
 
   RCLCPP_INFO(
     this->get_logger(),
-    "This driver is compatible with sensors running fw 2.x.");
+    "This driver is compatible with sensors running fw 2.2-2.4");
 
   _reset_srv = this->create_service<std_srvs::srv::Empty>(
     "~/reset", std::bind(&OusterDriver::resetService, this, _1, _2, _3));


### PR DESCRIPTION
As described in https://github.com/ros-drivers/ros2_ouster_drivers/issues/116 

Firmware 2.4 removes  auto_start_flag and udp_ip, and therefore the lidar communication is not established when the lidar is on the newer firmware.

v2.3 has been pulled from the Ouster website / will not be supporting it at all moving forwards from what I understand.

This PR also might break backwards compatibility for lidars on older firmware, I have only tested this on v2.4 and v2.3 devices.