### PR TITLE
Fixed compile issue with newer version of jsoncpp

### DIFF
--- a/ros2_ouster/CMakeLists.txt
+++ b/ros2_ouster/CMakeLists.txt
@@ -21,7 +21,11 @@ find_package(tf2_ros REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(ouster_msgs REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
-find_package(jsoncpp REQUIRED)
+if(NOT TARGET JsonCpp::JsonCpp)
+  find_package(jsoncpp REQUIRED)
+elseif(NOT TARGET jsoncpp_lib)
+  add_library(jsoncpp_lib ALIAS JsonCpp::JsonCpp)
+endif()
 
 include_directories(
   include


### PR DESCRIPTION
This PR fixes the compile issue for newer version of jsoncpp available in the current version of Ubuntu 22.04.
