### PR TITLE
Fix CMake error caused by multiple JsonCpp target definitions

### DIFF
--- a/ros2_ouster/CMakeLists.txt
+++ b/ros2_ouster/CMakeLists.txt
@@ -21,7 +21,15 @@ find_package(tf2_ros REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(ouster_msgs REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
-find_package(jsoncpp REQUIRED)
+# Workaround for upstream JsonCpp bug:
+# https://github.com/open-source-parsers/jsoncpp/issues/1356
+# This checks if the JsonCpp::JsonCpp target already exists before
+# trying to find the jsoncpp package again. This prevents the
+# "cannot create imported target" CMake error when multiple
+# dependencies try to find jsoncpp.
+if(NOT TARGET JsonCpp::JsonCpp)
+  find_package(jsoncpp REQUIRED)
+endif()
 
 include_directories(
   include
@@ -67,7 +75,7 @@ ament_target_dependencies(${library_name}
 )
 
 target_link_libraries(${library_name}
-  jsoncpp_lib
+  JsonCpp::JsonCpp
   tins
   ${PCL_LIBRARIES}
 )


### PR DESCRIPTION
This PR fixes a CMake error that occurs when building ros2_ouster_drivers on Humble due to multiple definitions of the JsonCpp::JsonCpp target. The issue is caused by an upstream bug in JsonCpp (https://github.com/open-source-parsers/jsoncpp/issues/1356) and is triggered when multiple dependencies attempt to find and link against jsoncpp.

Here's an example of an error on the buildfarm:
https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__ros2_ouster__ubuntu_jammy_amd64__binary/89/

@SteveMacenski, would you be able to help get this in?